### PR TITLE
 多sheet页和多java模型读取时，只使用第一个java模型，后面的java模型无法使用

### DIFF
--- a/src/main/java/com/alibaba/excel/context/AnalysisContextImpl.java
+++ b/src/main/java/com/alibaba/excel/context/AnalysisContextImpl.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- *
  * @author jipengfei
  */
 public class AnalysisContextImpl implements AnalysisContext {
@@ -69,10 +68,18 @@ public class AnalysisContextImpl implements AnalysisContext {
     }
 
     public void setCurrentSheet(Sheet currentSheet) {
+        clearCurrentSheet();
         this.currentSheet = currentSheet;
         if (currentSheet.getClazz() != null) {
             buildExcelHeadProperty(currentSheet.getClazz(), null);
         }
+    }
+
+    private void clearCurrentSheet() {
+        this.currentSheet = null;
+        this.excelHeadProperty = null;
+        this.currentRowNum = null;
+        this.totalCount = null;
     }
 
     public ExcelTypeEnum getExcelType() {


### PR DESCRIPTION
在多个sheet页和多个java模型的情况下。出现只使用第一个java模型的问题