### PR TITLE
输出时合并单元格增加行合并选项

### DIFF
--- a/src/main/java/com/alibaba/excel/write/merge/LoopMergeStrategy.java
+++ b/src/main/java/com/alibaba/excel/write/merge/LoopMergeStrategy.java
@@ -13,24 +13,39 @@ import com.alibaba.excel.metadata.Head;
  */
 public class LoopMergeStrategy extends AbstractMergeStrategy {
     private int eachRow;
+    private int columnCount;
     private int columnIndex;
 
     public LoopMergeStrategy(int eachRow, int columnIndex) {
+        this(eachRow, 1, columnIndex);
+    }
+
+    public LoopMergeStrategy(int eachRow, int columnCount, int columnIndex) {
         if (eachRow < 1) {
             throw new IllegalArgumentException("EachRows must be greater than 1");
+        }
+        if (columnCount < 1) {
+            throw new IllegalArgumentException("ColumnCount must be greater than 1");
+        }
+        if (columnCount == 1 && eachRow == 1) {
+            throw new IllegalArgumentException("ColumnCount or eachRows must be greater than 1");
         }
         if (columnIndex < 0) {
             throw new IllegalArgumentException("ColumnIndex must be greater than 0");
         }
         this.eachRow = eachRow;
+        this.columnCount = columnCount;
         this.columnIndex = columnIndex;
     }
 
     @Override
     protected void merge(Sheet sheet, Cell cell, Head head, int relativeRowIndex) {
         if (head.getColumnIndex() == columnIndex && relativeRowIndex % eachRow == 0) {
-            CellRangeAddress cellRangeAddress = new CellRangeAddress(cell.getRowIndex(),
-                cell.getRowIndex() + eachRow - 1, cell.getColumnIndex(), cell.getColumnIndex());
+            CellRangeAddress cellRangeAddress = new CellRangeAddress(
+                cell.getRowIndex(),
+                cell.getRowIndex() + eachRow - 1,
+                cell.getColumnIndex(),
+                cell.getColumnIndex() + columnCount - 1);
             sheet.addMergedRegion(cellRangeAddress);
         }
     }


### PR DESCRIPTION
1、输出时合并单元格增加行合并选项，自由选择行列
2、如果合并单元格的结果仍然是一个单元格（没有合并任何单元格），结果其实是会失败的，增加了校验