### PR TITLE
is开头的字段名失败时，去前置is重试

### DIFF
--- a/src/main/java/com/alibaba/excel/util/ClassUtils.java
+++ b/src/main/java/com/alibaba/excel/util/ClassUtils.java
@@ -23,11 +23,12 @@ import com.alibaba.excel.metadata.BaseRowModel;
  * @author Jiaju Zhuang
  **/
 public class ClassUtils {
+    private static final String SPECIAL_BOOLEAN_PREFIX = "is";
     private static final Map<Class, SoftReference<FieldCache>> FIELD_CACHE =
         new ConcurrentHashMap<Class, SoftReference<FieldCache>>();
 
     public static void declaredFields(Class clazz, List<Field> defaultFieldList, Map<Integer, Field> customFiledMap,
-        Map<String, Field> ignoreMap, Boolean convertAllFiled) {
+                                      Map<String, Field> ignoreMap, Boolean convertAllFiled) {
         FieldCache fieldCache = getFieldCache(clazz, convertAllFiled);
         if (fieldCache != null) {
             defaultFieldList.addAll(fieldCache.getDefaultFieldList());
@@ -78,7 +79,7 @@ public class ClassUtils {
         Map<String, Field> ignoreMap = new HashMap<String, Field>(16);
 
         ExcelIgnoreUnannotated excelIgnoreUnannotated =
-            (ExcelIgnoreUnannotated)clazz.getAnnotation(ExcelIgnoreUnannotated.class);
+            (ExcelIgnoreUnannotated) clazz.getAnnotation(ExcelIgnoreUnannotated.class);
         for (Field field : tempFieldList) {
             ExcelIgnore excelIgnore = field.getAnnotation(ExcelIgnore.class);
             if (excelIgnore != null) {
@@ -116,6 +117,18 @@ public class ClassUtils {
             new SoftReference<FieldCache>(new FieldCache(defaultFieldList, customFiledMap, allFieldList, ignoreMap)));
     }
 
+    /**
+     * get boolean field alias starts with 'is'
+     * @param name name like 'isActive'
+     * @return like 'active', or itself
+     */
+    public static String getBooleanFieldAlias(String name) {
+        if (name.startsWith(SPECIAL_BOOLEAN_PREFIX) && name.length() > SPECIAL_BOOLEAN_PREFIX.length()) {
+            return Character.toLowerCase(name.charAt(2)) + name.substring(3);
+        }
+        return name;
+    }
+
     private static class FieldCache {
         private List<Field> defaultFieldList;
         private Map<Integer, Field> customFiledMap;
@@ -123,7 +136,7 @@ public class ClassUtils {
         private Map<String, Field> ignoreMap;
 
         public FieldCache(List<Field> defaultFieldList, Map<Integer, Field> customFiledMap, List<Field> allFieldList,
-            Map<String, Field> ignoreMap) {
+                          Map<String, Field> ignoreMap) {
             this.defaultFieldList = defaultFieldList;
             this.customFiledMap = customFiledMap;
             this.allFieldList = allFieldList;

--- a/src/main/java/com/alibaba/excel/write/executor/ExcelWriteAddExecutor.java
+++ b/src/main/java/com/alibaba/excel/write/executor/ExcelWriteAddExecutor.java
@@ -60,7 +60,7 @@ public class ExcelWriteAddExecutor extends AbstractExcelWriteExecutor {
         Row row = WorkBookUtil.createRow(writeContext.writeSheetHolder().getSheet(), n);
         WriteHandlerUtils.afterRowCreate(writeContext, row, relativeRowIndex, Boolean.FALSE);
         if (oneRowData instanceof List) {
-            addBasicTypeToExcel((List)oneRowData, row, relativeRowIndex);
+            addBasicTypeToExcel((List) oneRowData, row, relativeRowIndex);
         } else {
             addJavaObjectToExcel(oneRowData, row, relativeRowIndex, fieldList);
         }
@@ -96,7 +96,7 @@ public class ExcelWriteAddExecutor extends AbstractExcelWriteExecutor {
     }
 
     private void doAddBasicTypeToExcel(List<Object> oneRowData, Head head, Row row, int relativeRowIndex, int dataIndex,
-        int cellIndex) {
+                                       int cellIndex) {
         if (writeContext.currentWriteHolder().ignore(null, cellIndex)) {
             return;
         }
@@ -127,7 +127,10 @@ public class ExcelWriteAddExecutor extends AbstractExcelWriteExecutor {
                     continue;
                 }
                 if (!beanMap.containsKey(name)) {
-                    continue;
+                    name = ClassUtils.getBooleanFieldAlias(name);
+                    if (!beanMap.containsKey(name)) {
+                        continue;
+                    }
                 }
                 Head head = headMap.get(cellIndex);
                 WriteHandlerUtils.beforeCellCreate(writeContext, row, head, cellIndex, relativeRowIndex, Boolean.FALSE);

--- a/src/test/java/com/alibaba/easyexcel/test/temp/ClassUtilsTest.java
+++ b/src/test/java/com/alibaba/easyexcel/test/temp/ClassUtilsTest.java
@@ -1,0 +1,16 @@
+package com.alibaba.easyexcel.test.temp;
+
+import com.alibaba.excel.util.ClassUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ClassUtilsTest {
+
+    @Test
+    public void getBooleanFieldAlias() {
+        final String active = ClassUtils.getBooleanFieldAlias("isActive");
+        assertEquals("active", active);
+    }
+}


### PR DESCRIPTION
字段名字如果以is开头会被ide截断，
IDE生成的Boolean字段的getter会被去掉字段前的is，
增加去掉is重试