### PR TITLE
fix: java.lang.UnsupportedOperationException: null

### DIFF
--- a/src/main/java/com/alibaba/excel/metadata/AbstractHolder.java
+++ b/src/main/java/com/alibaba/excel/metadata/AbstractHolder.java
@@ -1,9 +1,10 @@
 package com.alibaba.excel.metadata;
 
+import com.alibaba.excel.converters.Converter;
+
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
-import com.alibaba.excel.converters.Converter;
 
 /**
  * Write/read holder
@@ -38,15 +39,20 @@ public abstract class AbstractHolder implements ConfigurationHolder {
 
     public AbstractHolder(BasicParameter basicParameter, AbstractHolder prentAbstractHolder) {
         this.newInitialization = Boolean.TRUE;
-        if (basicParameter.getHead() == null && basicParameter.getClazz() == null && prentAbstractHolder != null) {
+        final List<List<String>> basicHead = basicParameter.getHead();
+        if (basicHead == null && basicParameter.getClazz() == null && prentAbstractHolder != null) {
+            this.clazz = prentAbstractHolder.getClazz();
             this.head = prentAbstractHolder.getHead();
         } else {
-            this.head = basicParameter.getHead();
-        }
-        if (basicParameter.getHead() == null && basicParameter.getClazz() == null && prentAbstractHolder != null) {
-            this.clazz = prentAbstractHolder.getClazz();
-        } else {
             this.clazz = basicParameter.getClazz();
+            if (basicHead != null) {
+                //The basicParameter head list may not implement the List#add(T t) method.
+                final List<List<String>> safeBasicHead = new LinkedList<List<String>>();
+                for (List<String> headStringList : basicHead) {
+                    safeBasicHead.add(new LinkedList<String>(headStringList));
+                }
+                this.head = safeBasicHead;
+            }
         }
         this.globalConfiguration = new GlobalConfiguration();
         if (basicParameter.getAutoTrim() == null) {


### PR DESCRIPTION
既使用动态表头又使用实体类时，当动态表头中的list为没有实现AbstractList
的add方法的简易类时，抛出`java.lang.UnsupportedOperationException: null`的问题 #881