### PR TITLE
优化JVM回收性能问题

### DIFF
--- a/src/test/java/com/alibaba/easyexcel/test/demo/read/CellDataDemoHeadDataListener.java
+++ b/src/test/java/com/alibaba/easyexcel/test/demo/read/CellDataDemoHeadDataListener.java
@@ -23,14 +23,14 @@ public class CellDataDemoHeadDataListener extends AnalysisEventListener<CellData
      * 每隔5条存储数据库，实际使用中可以3000条，然后清理list ，方便内存回收
      */
     private static final int BATCH_COUNT = 5;
-    List<CellDataReadDemoData> list = new ArrayList<CellDataReadDemoData>();
+    List<CellDataReadDemoData> list = new ArrayList<CellDataReadDemoData>(BATCH_COUNT);
 
     @Override
     public void invoke(CellDataReadDemoData data, AnalysisContext context) {
         LOGGER.info("解析到一条数据:{}", JSON.toJSONString(data));
         if (list.size() >= BATCH_COUNT) {
             saveData();
-            list.clear();
+            list = new ArrayList<CellDataReadDemoData>(BATCH_COUNT);
         }
     }
 

--- a/src/test/java/com/alibaba/easyexcel/test/demo/read/ConverterDataListener.java
+++ b/src/test/java/com/alibaba/easyexcel/test/demo/read/ConverterDataListener.java
@@ -21,7 +21,7 @@ public class ConverterDataListener extends AnalysisEventListener<ConverterData> 
      * 每隔5条存储数据库，实际使用中可以3000条，然后清理list ，方便内存回收
      */
     private static final int BATCH_COUNT = 5;
-    List<ConverterData> list = new ArrayList<ConverterData>();
+    List<ConverterData> list = new ArrayList<ConverterData>(BATCH_COUNT);
 
     @Override
     public void invoke(ConverterData data, AnalysisContext context) {
@@ -29,7 +29,7 @@ public class ConverterDataListener extends AnalysisEventListener<ConverterData> 
         list.add(data);
         if (list.size() >= BATCH_COUNT) {
             saveData();
-            list.clear();
+            list = new ArrayList<ConverterData>(BATCH_COUNT);
         }
     }
 

--- a/src/test/java/com/alibaba/easyexcel/test/demo/read/DemoDataListener.java
+++ b/src/test/java/com/alibaba/easyexcel/test/demo/read/DemoDataListener.java
@@ -22,7 +22,7 @@ public class DemoDataListener extends AnalysisEventListener<DemoData> {
      * 每隔5条存储数据库，实际使用中可以3000条，然后清理list ，方便内存回收
      */
     private static final int BATCH_COUNT = 5;
-    List<DemoData> list = new ArrayList<DemoData>();
+    List<DemoData> list = new ArrayList<DemoData>(BATCH_COUNT);
     /**
      * 假设这个是一个DAO，当然有业务逻辑这个也可以是一个service。当然如果不用存储这个对象没用。
      */
@@ -57,7 +57,7 @@ public class DemoDataListener extends AnalysisEventListener<DemoData> {
         if (list.size() >= BATCH_COUNT) {
             saveData();
             // 存储完成清理 list
-            list.clear();
+            list = new ArrayList<DemoData>(BATCH_COUNT);
         }
     }
 

--- a/src/test/java/com/alibaba/easyexcel/test/demo/read/DemoExceptionListener.java
+++ b/src/test/java/com/alibaba/easyexcel/test/demo/read/DemoExceptionListener.java
@@ -23,7 +23,7 @@ public class DemoExceptionListener extends AnalysisEventListener<ExceptionDemoDa
      * 每隔5条存储数据库，实际使用中可以3000条，然后清理list ，方便内存回收
      */
     private static final int BATCH_COUNT = 5;
-    List<ExceptionDemoData> list = new ArrayList<ExceptionDemoData>();
+    List<ExceptionDemoData> list = new ArrayList<ExceptionDemoData>(BATCH_COUNT);
 
     /**
      * 在转换异常 获取其他异常下会调用本接口。抛出异常则停止读取。如果这里不抛出异常则 继续读取下一行。
@@ -60,7 +60,7 @@ public class DemoExceptionListener extends AnalysisEventListener<ExceptionDemoDa
         LOGGER.info("解析到一条数据:{}", JSON.toJSONString(data));
         if (list.size() >= BATCH_COUNT) {
             saveData();
-            list.clear();
+            list = new ArrayList<ExceptionDemoData>(BATCH_COUNT);
         }
     }
 

--- a/src/test/java/com/alibaba/easyexcel/test/demo/read/DemoHeadDataListener.java
+++ b/src/test/java/com/alibaba/easyexcel/test/demo/read/DemoHeadDataListener.java
@@ -24,7 +24,7 @@ public class DemoHeadDataListener extends AnalysisEventListener<DemoData> {
      * 每隔5条存储数据库，实际使用中可以3000条，然后清理list ，方便内存回收
      */
     private static final int BATCH_COUNT = 5;
-    List<DemoData> list = new ArrayList<DemoData>();
+    List<DemoData> list = new ArrayList<DemoData>(BATCH_COUNT);
 
     /**
      * 在转换异常 获取其他异常下会调用本接口。抛出异常则停止读取。如果这里不抛出异常则 继续读取下一行。
@@ -59,7 +59,7 @@ public class DemoHeadDataListener extends AnalysisEventListener<DemoData> {
         LOGGER.info("解析到一条数据:{}", JSON.toJSONString(data));
         if (list.size() >= BATCH_COUNT) {
             saveData();
-            list.clear();
+            list = new ArrayList<DemoData>(BATCH_COUNT);
         }
     }
 

--- a/src/test/java/com/alibaba/easyexcel/test/demo/read/IndexOrNameDataListener.java
+++ b/src/test/java/com/alibaba/easyexcel/test/demo/read/IndexOrNameDataListener.java
@@ -21,7 +21,7 @@ public class IndexOrNameDataListener extends AnalysisEventListener<IndexOrNameDa
      * 每隔5条存储数据库，实际使用中可以3000条，然后清理list ，方便内存回收
      */
     private static final int BATCH_COUNT = 5;
-    List<IndexOrNameData> list = new ArrayList<IndexOrNameData>();
+    List<IndexOrNameData> list = new ArrayList<IndexOrNameData>(BATCH_COUNT);
 
     @Override
     public void invoke(IndexOrNameData data, AnalysisContext context) {
@@ -29,7 +29,7 @@ public class IndexOrNameDataListener extends AnalysisEventListener<IndexOrNameDa
         list.add(data);
         if (list.size() >= BATCH_COUNT) {
             saveData();
-            list.clear();
+            list = new ArrayList<IndexOrNameData>(BATCH_COUNT);
         }
     }
 

--- a/src/test/java/com/alibaba/easyexcel/test/demo/read/NoModleDataListener.java
+++ b/src/test/java/com/alibaba/easyexcel/test/demo/read/NoModleDataListener.java
@@ -22,7 +22,7 @@ public class NoModleDataListener extends AnalysisEventListener<Map<Integer, Stri
      * 每隔5条存储数据库，实际使用中可以3000条，然后清理list ，方便内存回收
      */
     private static final int BATCH_COUNT = 5;
-    List<Map<Integer, String>> list = new ArrayList<Map<Integer, String>>();
+    List<Map<Integer, String>> list = new ArrayList<Map<Integer, String>>(BATCH_COUNT);
 
     @Override
     public void invoke(Map<Integer, String> data, AnalysisContext context) {
@@ -30,7 +30,7 @@ public class NoModleDataListener extends AnalysisEventListener<Map<Integer, Stri
         list.add(data);
         if (list.size() >= BATCH_COUNT) {
             saveData();
-            list.clear();
+            list = new ArrayList<Map<Integer, String>>(BATCH_COUNT);
         }
     }
 

--- a/src/test/java/com/alibaba/easyexcel/test/demo/web/UploadDataListener.java
+++ b/src/test/java/com/alibaba/easyexcel/test/demo/web/UploadDataListener.java
@@ -23,7 +23,7 @@ public class UploadDataListener extends AnalysisEventListener<UploadData> {
      * 每隔5条存储数据库，实际使用中可以3000条，然后清理list ，方便内存回收
      */
     private static final int BATCH_COUNT = 5;
-    List<UploadData> list = new ArrayList<UploadData>();
+    List<UploadData> list = new ArrayList<UploadData>(BATCH_COUNT);
     /**
      * 假设这个是一个DAO，当然有业务逻辑这个也可以是一个service。当然如果不用存储这个对象没用。
      */
@@ -58,7 +58,7 @@ public class UploadDataListener extends AnalysisEventListener<UploadData> {
         if (list.size() >= BATCH_COUNT) {
             saveData();
             // 存储完成清理 list
-            list.clear();
+            list = new ArrayList<UploadData>(BATCH_COUNT);
         }
     }
 

--- a/src/test/java/com/alibaba/easyexcel/test/temp/LockDataListener.java
+++ b/src/test/java/com/alibaba/easyexcel/test/temp/LockDataListener.java
@@ -22,7 +22,7 @@ public class LockDataListener extends AnalysisEventListener<LockData> {
      * 每隔5条存储数据库，实际使用中可以3000条，然后清理list ，方便内存回收
      */
     private static final int BATCH_COUNT = 5;
-    List<LockData> list = new ArrayList<LockData>();
+    List<LockData> list = new ArrayList<LockData>(BATCH_COUNT);
 
     @Override
     public void invoke(LockData data, AnalysisContext context) {
@@ -30,7 +30,7 @@ public class LockDataListener extends AnalysisEventListener<LockData> {
         list.add(data);
         if (list.size() >= BATCH_COUNT) {
             saveData();
-            list.clear();
+            list = new ArrayList<LockData>(BATCH_COUNT);
         }
     }
 

--- a/src/test/java/com/alibaba/easyexcel/test/temp/simple/RepeatListener.java
+++ b/src/test/java/com/alibaba/easyexcel/test/temp/simple/RepeatListener.java
@@ -23,7 +23,7 @@ public class RepeatListener extends AnalysisEventListener<LockData> {
      * 每隔5条存储数据库，实际使用中可以3000条，然后清理list ，方便内存回收
      */
     private static final int BATCH_COUNT = 5;
-    List<LockData> list = new ArrayList<LockData>();
+    List<LockData> list = new ArrayList<LockData>(BATCH_COUNT);
 
     @Override
     public void invoke(LockData data, AnalysisContext context) {
@@ -31,7 +31,7 @@ public class RepeatListener extends AnalysisEventListener<LockData> {
         list.add(data);
         if (list.size() >= BATCH_COUNT) {
             saveData();
-            list.clear();
+            list = new ArrayList<LockData>(BATCH_COUNT);
         }
     }
 


### PR DESCRIPTION
在样例中，**list.clear()**。使得JVM回收。但其实性能非常的差，看源码为O(n)。
因此直接改为**list = new ArrayList<CellDataReadDemoData>(BATCH_COUNT)**;  性能为O(1)
同时指定大小，养成不浪费内存的习惯。

使得后续使用者能按照比较优的样例来实践。