### PR TITLE
修改issue #1046(当类的属性没有按照ExcelProperty的属性index顺序排序的时候，写数据出现错乱)

### DIFF
--- a/src/main/java/com/alibaba/excel/util/ClassUtils.java
+++ b/src/main/java/com/alibaba/excel/util/ClassUtils.java
@@ -109,11 +109,12 @@ public class ClassUtils {
                     + "' and '" + field.getName() + "' must be inconsistent");
             }
             customFiledMap.put(excelProperty.index(), field);
-            allFieldList.add(field);
         }
 
+        List<Field> allWriteFieldList = new ArrayList<Field>(customFiledMap.values());
+        allWriteFieldList.addAll(allFieldList);
         FIELD_CACHE.put(clazz,
-            new SoftReference<FieldCache>(new FieldCache(defaultFieldList, customFiledMap, allFieldList, ignoreMap)));
+            new SoftReference<FieldCache>(new FieldCache(defaultFieldList, customFiledMap, allWriteFieldList, ignoreMap)));
     }
 
     private static class FieldCache {


### PR DESCRIPTION
修改issue #1046 ，我首先把加了ExcelProperty注解的属性给放置到allWriteFieldList中，之后后面添加没有添加ExcelProperty(这个应该是在没有在class上加ExcelIgnoreUnannotated注解的时候)注解的属性。