### PR TITLE
新增按照单元格内容相同进行合并单元格的策略

### DIFF
--- a/src/main/java/com/alibaba/excel/enums/MergeTypeEnum.java
+++ b/src/main/java/com/alibaba/excel/enums/MergeTypeEnum.java
@@ -1,0 +1,56 @@
+package com.alibaba.excel.enums;
+
+/**
+ * 合并单元格类型
+ * Merge cell types
+ * 1 水平方向合并
+ * Merge horizontally
+ * 2 垂直方向合并
+ * Merge vertically
+ * 3 先水平，然后垂直方向合并
+ * Merge first horizontally, then vertically
+ * @author Lucas xie
+ * @date 2020-1-17
+ * @since 1.0.0L
+ */
+public enum MergeTypeEnum {
+    /**
+     * 水平方向合并
+     * Merge horizontally
+     */
+    HORIZONTAL_MERGE(1),
+    /**
+     * 垂直方向合并
+     * Merge vertically
+     */
+    VERTICAL_MERGE(2),
+    /**
+     * 先水平，然后垂直方向合并
+     * Merge first horizontally, then vertically
+     */
+    CENTER_MERGE(3);
+
+    /**
+     * 类型
+     * type
+     */
+    private int type;
+    /**
+     * 获取索引值
+     * Get the index value
+     */
+    public int index;
+
+    MergeTypeEnum(int type){
+        this.type = type;
+        this.index = type;
+    }
+
+    /**
+     * 获取类型值
+     * Get type value
+     */
+    public int getType() {
+        return type;
+    }
+}

--- a/src/main/java/com/alibaba/excel/metadata/CellPoint.java
+++ b/src/main/java/com/alibaba/excel/metadata/CellPoint.java
@@ -1,0 +1,75 @@
+package com.alibaba.excel.metadata;
+
+/**
+ * 用来定位连续的文字相同的起点和重点的单元格坐标对象
+ * @author Lucas xie
+ * @date 2020-1-17
+ * @since 1.0.0L
+ */
+public class CellPoint {
+    /**
+     * 开始单元格x坐标
+     * start cell x point
+     */
+    private int startX;
+    /**
+     * 结束单元格x坐标
+     * end cell x point
+     */
+    private int endX;
+    /**
+     * 开始单元格y坐标
+     * start cell y point
+     */
+    private int startY;
+    /**
+     * 结束单元格y坐标
+     * end cell y point
+     */
+    private int endY;
+    /**
+     * 单元格内容，文本
+     * cell content, text
+     */
+    private String text;
+
+    public int getStartX() {
+        return startX;
+    }
+
+    public void setStartX(int startX) {
+        this.startX = startX;
+    }
+
+    public int getEndX() {
+        return endX;
+    }
+
+    public void setEndX(int endX) {
+        this.endX = endX;
+    }
+
+    public int getStartY() {
+        return startY;
+    }
+
+    public void setStartY(int startY) {
+        this.startY = startY;
+    }
+
+    public int getEndY() {
+        return endY;
+    }
+
+    public void setEndY(int endY) {
+        this.endY = endY;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+}

--- a/src/main/java/com/alibaba/excel/write/merge/TextSameMergeStrategy.java
+++ b/src/main/java/com/alibaba/excel/write/merge/TextSameMergeStrategy.java
@@ -1,0 +1,154 @@
+package com.alibaba.excel.write.merge;
+
+import com.alibaba.excel.enums.MergeTypeEnum;
+import com.alibaba.excel.metadata.CellPoint;
+import com.alibaba.excel.metadata.Head;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.util.CellRangeAddress;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 文本相同单元格合并，支持行合并和列合并, 行列同事合并
+ * Text same cell merge, <p>
+ *     support row and column merge, row and column colleagues merge
+ * @author Lucas xie
+ * @date 2020-1-17
+ * @since 1.0.0L
+ */
+public class TextSameMergeStrategy extends AbstractMergeStrategy {
+
+    /**
+     * 临时列存储
+     * Temporary col storage
+     */
+    Map<String, CellPoint> col = new HashMap<String, CellPoint>();
+
+    /**
+     * 临时行存储
+     * Temporary row storage
+     */
+    Map<String, CellPoint> row = new HashMap<String, CellPoint>();
+
+    /**
+     * 总列数
+     * Total number of rows
+     */
+    private int totalCols;
+    /**
+     * 总行数
+     */
+    private int totalRows;
+
+    private int mergeType;
+
+    /**
+     * 构造方法传入 总行数、总列数
+     * The constructor passes in the total number of rows and columns
+     * @param totalCols
+     * @param totalRows
+     * @param mergeType
+     */
+    public TextSameMergeStrategy(int totalCols, int totalRows, MergeTypeEnum mergeType) {
+        this.totalCols = totalCols;
+        this.totalRows = totalRows;
+        this.mergeType = mergeType.index;
+    }
+
+    @Override
+    protected void merge(Sheet sheet, Cell cell, Head head, Integer i) {
+        // 行合并
+        if (this.mergeType == MergeTypeEnum.HORIZONTAL_MERGE.index) {
+            this.horizontalMerge(cell, i, sheet);
+        }
+        // 列合并
+        if (this.mergeType == MergeTypeEnum.VERTICAL_MERGE.index) {
+            this.verticalMerge(cell, head, i, sheet);
+        }
+        // 先行后列合并
+        if (this.mergeType == MergeTypeEnum.CENTER_MERGE.index) {
+            this.horizontalMerge(cell, i, sheet);
+            this.verticalMerge(cell, head, i, sheet);
+        }
+    }
+
+    /**
+     * 水平合并 行合并
+     * Horizontal merge row merge
+     * @param cell
+     * @param index
+     * @param sheet
+     */
+    private void horizontalMerge(Cell cell, Integer index, Sheet sheet){
+        String key = sheet.getSheetName()+"R"+index;
+        CellPoint rowCellPoint = row.get(key);
+        if(rowCellPoint == null){
+            row.put(key, new CellPoint());
+            rowCellPoint = row.get(key);
+        }
+        rowCellPoint.setStartY(cell.getRowIndex());
+        rowCellPoint.setEndY(cell.getRowIndex());
+
+        if(rowCellPoint.getText() != null && rowCellPoint.getText().equals(cell.getStringCellValue())){
+            rowCellPoint.setEndX(cell.getColumnIndex());
+            if(this.totalCols-1 == cell.getColumnIndex()){
+                this.executorMerge(rowCellPoint, sheet);
+            }
+        }else{
+            if(rowCellPoint.getStartX() < rowCellPoint.getEndX()){
+                this.executorMerge(rowCellPoint, sheet);
+            }
+            rowCellPoint.setStartX(cell.getColumnIndex());
+        }
+        rowCellPoint.setText(cell.getStringCellValue());
+    }
+
+    /**
+     * 垂直合并 列合并
+     * Vertical merge column merge
+     * @param cell 单元格
+     * @param head 表头
+     * @param index 行索引
+     * @param sheet sheet
+     */
+    public void verticalMerge(Cell cell, Head head, Integer index, Sheet sheet){
+        CellPoint cellPoint = col.get(sheet.getSheetName()+"C"+cell.getColumnIndex());
+        if(cellPoint == null){
+            col.put(sheet.getSheetName()+"C"+cell.getColumnIndex(), new CellPoint());
+            cellPoint = col.get(sheet.getSheetName()+"C"+cell.getColumnIndex());
+        }
+        if(cellPoint.getText() != null && cellPoint.getText().equals(cell.getStringCellValue())){
+            cellPoint.setEndX(cell.getColumnIndex());
+            cellPoint.setEndY(cell.getRowIndex());
+            if(index == totalRows-1){
+                this.executorMerge(cellPoint, sheet);
+            }
+        }else{
+            if(cellPoint.getStartY() != cellPoint.getEndY()){
+                this.executorMerge(cellPoint, sheet);
+            }
+            cellPoint.setStartX(cell.getColumnIndex());
+            cellPoint.setStartY(cell.getRowIndex());
+            cellPoint.setEndX(cell.getColumnIndex());
+            cellPoint.setEndY(cell.getRowIndex());
+        }
+        cellPoint.setText(cell.getStringCellValue());
+    }
+
+    /**
+     * 执行合并
+     * Perform merge
+     * @param sheet sheet的对象
+     * @param cellPoint 单元格坐标对象
+     */
+    private void executorMerge(CellPoint cellPoint, Sheet sheet){
+        CellRangeAddress cellRangeAddress = new CellRangeAddress(
+                cellPoint.getStartY(),
+                cellPoint.getEndY(),
+                cellPoint.getStartX(),
+                cellPoint.getEndX());
+        sheet.addMergedRegionUnsafe(cellRangeAddress);
+    }
+}

--- a/src/main/java/com/alibaba/excel/write/merge/TextSameMergeStrategy.java
+++ b/src/main/java/com/alibaba/excel/write/merge/TextSameMergeStrategy.java
@@ -1,12 +1,15 @@
 package com.alibaba.excel.write.merge;
 
+import com.alibaba.excel.enums.CellDataTypeEnum;
 import com.alibaba.excel.enums.MergeTypeEnum;
 import com.alibaba.excel.metadata.CellPoint;
 import com.alibaba.excel.metadata.Head;
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.util.CellRangeAddress;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -119,7 +122,7 @@ public class TextSameMergeStrategy extends AbstractMergeStrategy {
             col.put(sheet.getSheetName()+"C"+cell.getColumnIndex(), new CellPoint());
             cellPoint = col.get(sheet.getSheetName()+"C"+cell.getColumnIndex());
         }
-        if(cellPoint.getText() != null && cellPoint.getText().equals(cell.getStringCellValue())){
+        if(cellPoint.getText() != null && cellPoint.getText().equals(this.getCellText(cell))){
             cellPoint.setEndX(cell.getColumnIndex());
             cellPoint.setEndY(cell.getRowIndex());
             if(index == totalRows-1){
@@ -134,7 +137,7 @@ public class TextSameMergeStrategy extends AbstractMergeStrategy {
             cellPoint.setEndX(cell.getColumnIndex());
             cellPoint.setEndY(cell.getRowIndex());
         }
-        cellPoint.setText(cell.getStringCellValue());
+        cellPoint.setText(this.getCellText(cell));
     }
 
     /**
@@ -150,5 +153,26 @@ public class TextSameMergeStrategy extends AbstractMergeStrategy {
                 cellPoint.getStartX(),
                 cellPoint.getEndX());
         sheet.addMergedRegionUnsafe(cellRangeAddress);
+    }
+
+    /**
+     * 获取单元格的内容，转为字符串
+     * Get the contents of a cell and convert it to a string
+     * @param cell
+     * @return
+     */
+    private String getCellText(Cell cell){
+        String text = "";
+        CellType cellType = cell.getCellTypeEnum();
+        if(CellType.BOOLEAN.equals(cellType)){
+            text = Boolean.toString(cell.getBooleanCellValue());
+        }else if(CellType.NUMERIC.equals(cellType)){
+            text = Double.toString(cell.getNumericCellValue());
+        }else if(CellType.STRING.equals(cellType)){
+            text = cell.getStringCellValue();
+        }else if(cell.getCellTypeEnum().equals(Date.class)){
+            text = cell.getDateCellValue().toString();
+        }
+        return text;
     }
 }

--- a/src/test/java/com/alibaba/easyexcel/test/demo/write/WriteTest.java
+++ b/src/test/java/com/alibaba/easyexcel/test/demo/write/WriteTest.java
@@ -9,6 +9,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.alibaba.excel.enums.MergeTypeEnum;
+import com.alibaba.excel.write.merge.TextSameMergeStrategy;
 import org.apache.poi.ss.usermodel.FillPatternType;
 import org.apache.poi.ss.usermodel.IndexedColors;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
@@ -323,6 +325,24 @@ public class WriteTest {
         LoopMergeStrategy loopMergeStrategy = new LoopMergeStrategy(2, 0);
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
         EasyExcel.write(fileName, DemoData.class).registerWriteHandler(loopMergeStrategy).sheet("模板").doWrite(data());
+    }
+
+    /**
+     * 按照相同的内容自动合并单元格
+     * <p>
+     * 1. 创建excel对应的实体对象 参照{@link DemoData}
+     * <p>
+     * 2. 创建一个merge策略 并注册
+     * <p>
+     * 3. 直接写即可
+     */
+    @Test
+    public void mergeWriteBySameContent() {
+        String fileName = TestFileUtil.getPath() + "mergeWriteBySameContent" + System.currentTimeMillis() + ".xlsx";
+        // 每隔2行会合并 把eachColumn 设置成 3 也就是我们数据的长度，所以就第一列会合并。当然其他合并策略也可以自己写
+        TextSameMergeStrategy textSameMergeStrategy = new TextSameMergeStrategy(3, data().size(), MergeTypeEnum.VERTICAL_MERGE);
+        // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
+        EasyExcel.write(fileName, DemoData.class).registerWriteHandler(textSameMergeStrategy).sheet("模板").doWrite(data());
     }
 
     /**


### PR DESCRIPTION
新增按照单元格内容相同进行合并单元格的策略
例如
name | 价格 | 数量 | 备注
-|-|-
香蕉 | $1 | 5 | 好吃 |
苹果 | $1 | 6 | 好吃 |
草莓 | $1 | 7 | 好吃 |

备注这一列内容相同，进行合并了