### PR TITLE
更新解析excel出现问题 异常堆栈信息打印

### DIFF
--- a/src/main/java/com/alibaba/excel/analysis/v07/XlsxSaxAnalyser.java
+++ b/src/main/java/com/alibaba/excel/analysis/v07/XlsxSaxAnalyser.java
@@ -23,6 +23,8 @@ import org.apache.poi.xssf.usermodel.XSSFRelation;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTWorkbook;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTWorkbookPr;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.WorkbookDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
@@ -46,7 +48,7 @@ import com.alibaba.excel.util.StringUtils;
  * @author jipengfei
  */
 public class XlsxSaxAnalyser implements ExcelReadExecutor {
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(XlsxSaxAnalyser.class);
     private XlsxReadContext xlsxReadContext;
     private List<ReadSheet> sheetList;
     private Map<Integer, InputStream> sheetMap;
@@ -198,7 +200,11 @@ public class XlsxSaxAnalyser implements ExcelReadExecutor {
             readSheet = SheetUtils.match(readSheet, xlsxReadContext);
             if (readSheet != null) {
                 xlsxReadContext.currentSheet(readSheet);
-                parseXmlSource(sheetMap.get(readSheet.getSheetNo()), new XlsxRowHandler(xlsxReadContext));
+                try {
+                    parseXmlSource(sheetMap.get(readSheet.getSheetNo()), new XlsxRowHandler(xlsxReadContext));
+                }catch (Exception e){
+                    LOGGER.error("抛出异常：{}",e);
+                }
                 // Read comments
                 readComments(readSheet);
                 // The last sheet is read

--- a/src/test/java/com/alibaba/easyexcel/test/demo/read/IndexOrNameData.java
+++ b/src/test/java/com/alibaba/easyexcel/test/demo/read/IndexOrNameData.java
@@ -13,16 +13,20 @@ import lombok.Data;
  **/
 @Data
 public class IndexOrNameData {
-    /**
-     * 强制读取第三个 这里不建议 index 和 name 同时用，要么一个对象只用index，要么一个对象只用name去匹配
-     */
-    @ExcelProperty(index = 2)
-    private Double doubleData;
+
     /**
      * 用名字去匹配，这里需要注意，如果名字重复，会导致只有一个字段读取到数据
      */
-    @ExcelProperty("字符串标题")
+    private int id;
+
+    @ExcelProperty("字符串标")
     private String string;
     @ExcelProperty("日期标题")
     private Date date;
+
+    /**
+     * 强制读取第三个 这里不建议 index 和 name 同时用，要么一个对象只用index，要么一个对象只用name去匹配
+     */
+    @ExcelProperty("数字标题")
+    private Double doubleData;
 }


### PR DESCRIPTION
## bug 描述：
运营人员上传excel文件时，突然不解析数据，后端查看解析excel文件时突然异常中止，没有打印任何异常堆栈信息

## bug原因:

- 我们使用数据库和easyexcel 共用bean对象，对象内部需要解析的变量上则加注解@ExcelProperty("列名") 为easyexcel解析使用。

- 运营人员上传的excel文件 head行第一列有单词拼写错误，AbstractReadHolder类执行 buildHead 方法时，225行 的  if (headName.equals(headString)) 判断不满足，则会把这一行当做@ExcelProperty 不指定列名的方式处理。前面说数据库对象和easyexcel 是公用bean对象，我们第一个变量为long 型id

- 在206行有这个判断逻辑 `  if (headData.getForceIndex() || !headData.getForceName()) {
                tmpHeadMap.put(entry.getKey(), headData);
                tmpContentPropertyMap.put(entry.getKey(), contentPropertyMapData.get(entry.getKey()));
                continue;
            }` 先把第一列放到tmpHeadMap 中，而由于excel文件 第一列单词拼错，225行的判断逻辑无法走 `  if (headName.equals(headString)) ` 导致ExcelReadHeadProperty 存的head对象第一列是Long型。
 

- 我们的excel第一列解析出来是中文字符串。ModelBuildEventListener 执行invoke方法第一列匹配出 LongStringConverter 执行 parseLong方法出现类型转换异常。异常抛至XlsxSaxAnalyser parseXmlSource 方法catch后再抛。

- `     for (ReadSheet readSheet : sheetList) {
            readSheet = SheetUtils.match(readSheet, readSheetList, readAll,
                analysisContext.readWorkbookHolder().getGlobalConfiguration());
            if (readSheet != null) {
                analysisContext.currentSheet(readSheet);
                parseXmlSource(sheetMap.get(readSheet.getSheetNo()), new XlsxRowHandler(analysisContext, stylesTable));
                // The last sheet is read
                analysisContext.readSheetHolder().notifyAfterAllAnalysed(analysisContext);
            }
        }` 调用方没有对异常进行打印，导致程序中止，且没有异常信息。

## bug复现

- 可参考提交的IndexOrNameData单元测试类。
- 第一行解析对不上只有数据类型不一致才会出现问题。如果数据类型一致则不会有问题








