### PR TITLE
改变了列的导出顺序，同时修改了几个拼写错误

### DIFF
--- a/src/main/java/com/alibaba/excel/metadata/property/ExcelHeadProperty.java
+++ b/src/main/java/com/alibaba/excel/metadata/property/ExcelHeadProperty.java
@@ -1,6 +1,7 @@
 package com.alibaba.excel.metadata.property;
 
 import java.lang.reflect.Field;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -25,7 +26,6 @@ import com.alibaba.excel.util.ClassUtils;
 import com.alibaba.excel.util.StringUtils;
 import com.alibaba.excel.write.metadata.holder.AbstractWriteHolder;
 
-import javafx.util.Pair;
 
 /**
  * Define the header attribute of excel
@@ -76,7 +76,7 @@ public class ExcelHeadProperty {
             int headIndex = 0;
             for (int i = 0; i < head.size(); i++) {
                 if (holder instanceof AbstractWriteHolder) {
-                    if (((AbstractWriteHolder) holder).ignore(null, i)) {
+                    if (((AbstractWriteHolder)holder).ignore(null, i)) {
                         continue;
                     }
                 }
@@ -124,16 +124,17 @@ public class ExcelHeadProperty {
         Map<Integer, Field> customFieldMap = new TreeMap<Integer, Field>();
         ClassUtils.declaredFields(headClazz, defaultFieldList, customFieldMap, ignoreMap, convertAllField);
 
-        List<Pair<Field, Boolean>> exportFieldBoolPairsList = new ArrayList<Pair<Field, Boolean>>();
+        List<Map.Entry<Field, Boolean>> exportFieldBoolPairsList = new ArrayList<Map.Entry<Field, Boolean>>();
         int index = 0;
         while (customFieldMap.containsKey(index)) {
             Field field = customFieldMap.get(index);
-            Pair<Field, Boolean> fieldBooleanPair = new Pair<Field, Boolean>(field, Boolean.TRUE);
+            Map.Entry<Field, Boolean> fieldBooleanPair =
+                new AbstractMap.SimpleEntry<Field, Boolean>(field, Boolean.TRUE);
             exportFieldBoolPairsList.add(fieldBooleanPair);
             index++;
         }
         for (Field field : defaultFieldList) {
-            Pair<Field, Boolean> fieldBoolPair = new Pair<Field, Boolean>(field, Boolean.FALSE);
+            Map.Entry<Field, Boolean> fieldBoolPair = new AbstractMap.SimpleEntry<Field, Boolean>(field, Boolean.FALSE);
             exportFieldBoolPairsList.add(fieldBoolPair);
         }
 
@@ -147,8 +148,8 @@ public class ExcelHeadProperty {
     }
 
     /**
-     * Give the field and flag pair list and arrange them in the specified order according to the user's settings.
-     * The field is what the user want to export to excel, the flag indicates whether the order of the field in excel is
+     * Give the field and flag pair list and arrange them in the specified order according to the user's settings. The
+     * field is what the user want to export to excel, the flag indicates whether the order of the field in excel is
      * specified.
      *
      * @param holder
@@ -157,13 +158,14 @@ public class ExcelHeadProperty {
      *            Keep all the fields and the flag(which indicate whether the field order is specified) of the head
      *            class except the ignored. It will be modified after this function is called.
      */
-    private void sortExportColumnFields(Holder holder, List<Pair<Field, Boolean>> exportFieldBoolPairList) {
+    private void sortExportColumnFields(Holder holder, List<Map.Entry<Field, Boolean>> exportFieldBoolPairList) {
         if (holder instanceof AbstractWriteHolder) {
-            Collection<String> includeColumnFieldNames = ((AbstractWriteHolder) holder).getIncludeColumnFieldNames();
+            Collection<String> includeColumnFieldNames = ((AbstractWriteHolder)holder).getIncludeColumnFieldNames();
             if (includeColumnFieldNames != null) {
-                Map<String, Pair<Field, Boolean>> exportFieldMap = new TreeMap<String, Pair<Field, Boolean>>();
+                Map<String, Map.Entry<Field, Boolean>> exportFieldMap =
+                    new TreeMap<String, Map.Entry<Field, Boolean>>();
                 List<String> includeColumnFieldNameList = new ArrayList<String>(includeColumnFieldNames);
-                for (Pair<Field, Boolean> fieldBoolPair : exportFieldBoolPairList) {
+                for (Map.Entry<Field, Boolean> fieldBoolPair : exportFieldBoolPairList) {
                     if (includeColumnFieldNameList.contains(fieldBoolPair.getKey().getName())) {
                         exportFieldMap.put(fieldBoolPair.getKey().getName(), fieldBoolPair);
                     }
@@ -175,9 +177,9 @@ public class ExcelHeadProperty {
                 return;
             }
 
-            Collection<Integer> includeColumnIndexes = ((AbstractWriteHolder) holder).getIncludeColumnIndexes();
+            Collection<Integer> includeColumnIndexes = ((AbstractWriteHolder)holder).getIncludeColumnIndexes();
             if (includeColumnIndexes != null) {
-                List<Pair<Field, Boolean>> tempFieldsList = new ArrayList<Pair<Field, Boolean>>();
+                List<Map.Entry<Field, Boolean>> tempFieldsList = new ArrayList<Map.Entry<Field, Boolean>>();
                 for (Integer includeColumnIndex : includeColumnIndexes) {
                     tempFieldsList.add(exportFieldBoolPairList.get(includeColumnIndex));
                 }
@@ -187,8 +189,8 @@ public class ExcelHeadProperty {
             }
 
             int index = 0;
-            for (Pair<Field, Boolean> fieldBoolPair : exportFieldBoolPairList) {
-                if (((AbstractWriteHolder) holder).ignore(fieldBoolPair.getKey().getName(), index)) {
+            for (Map.Entry<Field, Boolean> fieldBoolPair : exportFieldBoolPairList) {
+                if (((AbstractWriteHolder)holder).ignore(fieldBoolPair.getKey().getName(), index)) {
                     exportFieldBoolPairList.remove(fieldBoolPair);
                 }
                 index++;
@@ -202,12 +204,12 @@ public class ExcelHeadProperty {
      * @param holder
      *            Write holder which keeps the parameters of a sheet.
      * @param exportFieldBoolPairList
-     *            Keep the fields which will be exported to excel and the flag which indicates whether
-     *            the field order in excel is specified.
+     *            Keep the fields which will be exported to excel and the flag which indicates whether the field order
+     *            in excel is specified.
      */
-    private void initColumnProperties(Holder holder, List<Pair<Field, Boolean>> exportFieldBoolPairList) {
+    private void initColumnProperties(Holder holder, List<Map.Entry<Field, Boolean>> exportFieldBoolPairList) {
         int index = 0;
-        for (Pair<Field, Boolean> fieldBoolPair : exportFieldBoolPairList) {
+        for (Map.Entry<Field, Boolean> fieldBoolPair : exportFieldBoolPairList) {
             initOneColumnProperty(holder, index, fieldBoolPair.getKey(), fieldBoolPair.getValue());
             index++;
         }
@@ -224,7 +226,7 @@ public class ExcelHeadProperty {
      */
     private boolean initOneColumnProperty(Holder holder, int index, Field field, Boolean forceIndex) {
         if (holder instanceof AbstractWriteHolder) {
-            if (((AbstractWriteHolder) holder).ignore(field.getName(), index)) {
+            if (((AbstractWriteHolder)holder).ignore(field.getName(), index)) {
                 return true;
             }
         }

--- a/src/main/java/com/alibaba/excel/write/builder/AbstractExcelWriterParameterBuilder.java
+++ b/src/main/java/com/alibaba/excel/write/builder/AbstractExcelWriterParameterBuilder.java
@@ -81,7 +81,7 @@ public abstract class AbstractExcelWriterParameterBuilder<T extends AbstractExce
      * Ignore the custom columns.
      */
     public T excludeColumnFiledNames(Collection<String> excludeColumnFiledNames) {
-        parameter().setExcludeColumnFiledNames(excludeColumnFiledNames);
+        parameter().setExcludeColumnFieldNames(excludeColumnFiledNames);
         return self();
     }
 
@@ -97,7 +97,7 @@ public abstract class AbstractExcelWriterParameterBuilder<T extends AbstractExce
      * Only output the custom columns.
      */
     public T includeColumnFiledNames(Collection<String> includeColumnFiledNames) {
-        parameter().setIncludeColumnFiledNames(includeColumnFiledNames);
+        parameter().setIncludeColumnFieldNames(includeColumnFiledNames);
         return self();
     }
 

--- a/src/main/java/com/alibaba/excel/write/metadata/WriteBasicParameter.java
+++ b/src/main/java/com/alibaba/excel/write/metadata/WriteBasicParameter.java
@@ -40,7 +40,7 @@ public class WriteBasicParameter extends BasicParameter {
     /**
      * Ignore the custom columns.
      */
-    private Collection<String> excludeColumnFiledNames;
+    private Collection<String> excludeColumnFieldNames;
     /**
      * Only output the custom columns.
      */
@@ -48,7 +48,7 @@ public class WriteBasicParameter extends BasicParameter {
     /**
      * Only output the custom columns.
      */
-    private Collection<String> includeColumnFiledNames;
+    private Collection<String> includeColumnFieldNames;
 
     public Integer getRelativeHeadRowIndex() {
         return relativeHeadRowIndex;
@@ -98,12 +98,12 @@ public class WriteBasicParameter extends BasicParameter {
         this.excludeColumnIndexes = excludeColumnIndexes;
     }
 
-    public Collection<String> getExcludeColumnFiledNames() {
-        return excludeColumnFiledNames;
+    public Collection<String> getExcludeColumnFieldNames() {
+        return excludeColumnFieldNames;
     }
 
-    public void setExcludeColumnFiledNames(Collection<String> excludeColumnFiledNames) {
-        this.excludeColumnFiledNames = excludeColumnFiledNames;
+    public void setExcludeColumnFieldNames(Collection<String> excludeColumnFieldNames) {
+        this.excludeColumnFieldNames = excludeColumnFieldNames;
     }
 
     public Collection<Integer> getIncludeColumnIndexes() {
@@ -114,12 +114,12 @@ public class WriteBasicParameter extends BasicParameter {
         this.includeColumnIndexes = includeColumnIndexes;
     }
 
-    public Collection<String> getIncludeColumnFiledNames() {
-        return includeColumnFiledNames;
+    public Collection<String> getIncludeColumnFieldNames() {
+        return includeColumnFieldNames;
     }
 
-    public void setIncludeColumnFiledNames(Collection<String> includeColumnFiledNames) {
-        this.includeColumnFiledNames = includeColumnFiledNames;
+    public void setIncludeColumnFieldNames(Collection<String> includeColumnFieldNames) {
+        this.includeColumnFieldNames = includeColumnFieldNames;
     }
 
 }

--- a/src/main/java/com/alibaba/excel/write/metadata/holder/AbstractWriteHolder.java
+++ b/src/main/java/com/alibaba/excel/write/metadata/holder/AbstractWriteHolder.java
@@ -82,7 +82,7 @@ public abstract class AbstractWriteHolder extends AbstractHolder implements Writ
     /**
      * Ignore the custom columns.
      */
-    private Collection<String> excludeColumnFiledNames;
+    private Collection<String> excludeColumnFieldNames;
     /**
      * Only output the custom columns.
      */
@@ -90,10 +90,10 @@ public abstract class AbstractWriteHolder extends AbstractHolder implements Writ
     /**
      * Only output the custom columns.
      */
-    private Collection<String> includeColumnFiledNames;
+    private Collection<String> includeColumnFieldNames;
 
     public AbstractWriteHolder(WriteBasicParameter writeBasicParameter, AbstractWriteHolder parentAbstractWriteHolder,
-        Boolean convertAllFiled) {
+        Boolean convertAllField) {
         super(writeBasicParameter, parentAbstractWriteHolder);
         if (writeBasicParameter.getUse1904windowing() == null) {
             if (parentAbstractWriteHolder == null) {
@@ -146,20 +146,20 @@ public abstract class AbstractWriteHolder extends AbstractHolder implements Writ
             this.automaticMergeHead = writeBasicParameter.getAutomaticMergeHead();
         }
 
-        if (writeBasicParameter.getExcludeColumnFiledNames() == null && parentAbstractWriteHolder != null) {
-            this.excludeColumnFiledNames = parentAbstractWriteHolder.getExcludeColumnFiledNames();
+        if (writeBasicParameter.getExcludeColumnFieldNames() == null && parentAbstractWriteHolder != null) {
+            this.excludeColumnFieldNames = parentAbstractWriteHolder.getExcludeColumnFieldNames();
         } else {
-            this.excludeColumnFiledNames = writeBasicParameter.getExcludeColumnFiledNames();
+            this.excludeColumnFieldNames = writeBasicParameter.getExcludeColumnFieldNames();
         }
         if (writeBasicParameter.getExcludeColumnIndexes() == null && parentAbstractWriteHolder != null) {
             this.excludeColumnIndexes = parentAbstractWriteHolder.getExcludeColumnIndexes();
         } else {
             this.excludeColumnIndexes = writeBasicParameter.getExcludeColumnIndexes();
         }
-        if (writeBasicParameter.getIncludeColumnFiledNames() == null && parentAbstractWriteHolder != null) {
-            this.includeColumnFiledNames = parentAbstractWriteHolder.getIncludeColumnFiledNames();
+        if (writeBasicParameter.getIncludeColumnFieldNames() == null && parentAbstractWriteHolder != null) {
+            this.includeColumnFieldNames = parentAbstractWriteHolder.getIncludeColumnFieldNames();
         } else {
-            this.includeColumnFiledNames = writeBasicParameter.getIncludeColumnFiledNames();
+            this.includeColumnFieldNames = writeBasicParameter.getIncludeColumnFieldNames();
         }
         if (writeBasicParameter.getIncludeColumnIndexes() == null && parentAbstractWriteHolder != null) {
             this.includeColumnIndexes = parentAbstractWriteHolder.getIncludeColumnIndexes();
@@ -168,7 +168,7 @@ public abstract class AbstractWriteHolder extends AbstractHolder implements Writ
         }
 
         // Initialization property
-        this.excelWriteHeadProperty = new ExcelWriteHeadProperty(this, getClazz(), getHead(), convertAllFiled);
+        this.excelWriteHeadProperty = new ExcelWriteHeadProperty(this, getClazz(), getHead(), convertAllField);
 
         // Compatible with old code
         compatibleOldCode(writeBasicParameter);
@@ -446,10 +446,10 @@ public abstract class AbstractWriteHolder extends AbstractHolder implements Writ
     @Override
     public boolean ignore(String fieldName, Integer columnIndex) {
         if (fieldName != null) {
-            if (includeColumnFiledNames != null && !includeColumnFiledNames.contains(fieldName)) {
+            if (includeColumnFieldNames != null && !includeColumnFieldNames.contains(fieldName)) {
                 return true;
             }
-            if (excludeColumnFiledNames != null && excludeColumnFiledNames.contains(fieldName)) {
+            if (excludeColumnFieldNames != null && excludeColumnFieldNames.contains(fieldName)) {
                 return true;
             }
         }
@@ -520,12 +520,12 @@ public abstract class AbstractWriteHolder extends AbstractHolder implements Writ
         this.excludeColumnIndexes = excludeColumnIndexes;
     }
 
-    public Collection<String> getExcludeColumnFiledNames() {
-        return excludeColumnFiledNames;
+    public Collection<String> getExcludeColumnFieldNames() {
+        return excludeColumnFieldNames;
     }
 
-    public void setExcludeColumnFiledNames(Collection<String> excludeColumnFiledNames) {
-        this.excludeColumnFiledNames = excludeColumnFiledNames;
+    public void setExcludeColumnFieldNames(Collection<String> excludeColumnFieldNames) {
+        this.excludeColumnFieldNames = excludeColumnFieldNames;
     }
 
     public Collection<Integer> getIncludeColumnIndexes() {
@@ -536,12 +536,12 @@ public abstract class AbstractWriteHolder extends AbstractHolder implements Writ
         this.includeColumnIndexes = includeColumnIndexes;
     }
 
-    public Collection<String> getIncludeColumnFiledNames() {
-        return includeColumnFiledNames;
+    public Collection<String> getIncludeColumnFieldNames() {
+        return includeColumnFieldNames;
     }
 
-    public void setIncludeColumnFiledNames(Collection<String> includeColumnFiledNames) {
-        this.includeColumnFiledNames = includeColumnFiledNames;
+    public void setIncludeColumnFieldNames(Collection<String> includeColumnFieldNames) {
+        this.includeColumnFieldNames = includeColumnFieldNames;
     }
 
     @Override


### PR DESCRIPTION
[根据参数导出指定列，能够根据参数顺序指定导出列的顺序](https://github.com/alibaba/easyexcel/issues/799)。当使用参数导出指定列时，使用参数的顺序作为导出列的顺序，感觉这样更符合人的思维习惯，比如在数据库中检索某些字段时，检索出的字段顺序和代码中的是一致的；不使用参数导出指定列时，导出列的顺序规则和以前一样