### PR TITLE
使用jacoco插件统计代码的 单元测试覆盖率

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,11 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.2</version>
+        </dependency>
     </dependencies>
     <distributionManagement>
         <snapshotRepository>
@@ -226,6 +231,26 @@
                         <id>attach-javadocs</id>
                         <goals>
                             <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.2</version>
+                <executions>
+                    <execution>
+                        <id>jacoco-initialize</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-site</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>report</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
运行mvn install 命令，可以在target/site/jacoco 文件夹下生成index.html文件，可以详细展示代码的测试覆盖情况。
![1](https://user-images.githubusercontent.com/50514813/80353192-92adc880-88a7-11ea-8b6e-1c42dd7b47b8.png)
