### PR TITLE
修复动态表头时，内容单元格的样式不生效的bug

### DIFF
--- a/src/main/java/com/alibaba/excel/write/style/AbstractCellStyleStrategy.java
+++ b/src/main/java/com/alibaba/excel/write/style/AbstractCellStyleStrategy.java
@@ -50,7 +50,7 @@ public abstract class AbstractCellStyleStrategy implements CellWriteHandler, Wor
     @Override
     public void afterCellDispose(WriteSheetHolder writeSheetHolder, WriteTableHolder writeTableHolder,
         List<CellData> cellDataList, Cell cell, Head head, Integer relativeRowIndex, Boolean isHead) {
-        if (isHead == null || head == null) {
+        if (isHead == null) {
             return;
         }
         if (isHead) {

--- a/src/test/java/com/alibaba/easyexcel/test/demo/write/WriteTest.java
+++ b/src/test/java/com/alibaba/easyexcel/test/demo/write/WriteTest.java
@@ -297,26 +297,7 @@ public class WriteTest {
     @Test
     public void handlerStyleWrite() {
         String fileName = TestFileUtil.getPath() + "handlerStyleWrite" + System.currentTimeMillis() + ".xlsx";
-        // 头的策略
-        WriteCellStyle headWriteCellStyle = new WriteCellStyle();
-        // 背景设置为红色
-        headWriteCellStyle.setFillForegroundColor(IndexedColors.RED.getIndex());
-        WriteFont headWriteFont = new WriteFont();
-        headWriteFont.setFontHeightInPoints((short)20);
-        headWriteCellStyle.setWriteFont(headWriteFont);
-        // 内容的策略
-        WriteCellStyle contentWriteCellStyle = new WriteCellStyle();
-        // 这里需要指定 FillPatternType 为FillPatternType.SOLID_FOREGROUND 不然无法显示背景颜色.头默认了 FillPatternType所以可以不指定
-        contentWriteCellStyle.setFillPatternType(FillPatternType.SOLID_FOREGROUND);
-        // 背景绿色
-        contentWriteCellStyle.setFillForegroundColor(IndexedColors.GREEN.getIndex());
-        WriteFont contentWriteFont = new WriteFont();
-        // 字体大小
-        contentWriteFont.setFontHeightInPoints((short)20);
-        contentWriteCellStyle.setWriteFont(contentWriteFont);
-        // 这个策略是 头是头的样式 内容是内容的样式 其他的策略可以自己实现
-        HorizontalCellStyleStrategy horizontalCellStyleStrategy =
-            new HorizontalCellStyleStrategy(headWriteCellStyle, contentWriteCellStyle);
+        HorizontalCellStyleStrategy horizontalCellStyleStrategy = newHorizontalCellStyleStrategy();
 
         // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
         EasyExcel.write(fileName, DemoData.class).registerWriteHandler(horizontalCellStyleStrategy).sheet("模板")
@@ -392,6 +373,7 @@ public class WriteTest {
         EasyExcel.write(fileName)
             // 这里放入动态头
             .head(head()).sheet("模板")
+            .registerWriteHandler(newHorizontalCellStyleStrategy())
             // 当然这里数据也可以用 List<List<String>> 去传入
             .doWrite(data());
     }
@@ -547,6 +529,28 @@ public class WriteTest {
             list.add(data);
         }
         return list;
+    }
+
+    private HorizontalCellStyleStrategy newHorizontalCellStyleStrategy() {
+        // 头的策略
+        WriteCellStyle headWriteCellStyle = new WriteCellStyle();
+        // 背景设置为红色
+        headWriteCellStyle.setFillForegroundColor(IndexedColors.RED.getIndex());
+        WriteFont headWriteFont = new WriteFont();
+        headWriteFont.setFontHeightInPoints((short)20);
+        headWriteCellStyle.setWriteFont(headWriteFont);
+        // 内容的策略
+        WriteCellStyle contentWriteCellStyle = new WriteCellStyle();
+        // 这里需要指定 FillPatternType 为FillPatternType.SOLID_FOREGROUND 不然无法显示背景颜色.头默认了 FillPatternType所以可以不指定
+        contentWriteCellStyle.setFillPatternType(FillPatternType.SOLID_FOREGROUND);
+        // 背景绿色
+        contentWriteCellStyle.setFillForegroundColor(IndexedColors.GREEN.getIndex());
+        WriteFont contentWriteFont = new WriteFont();
+        // 字体大小
+        contentWriteFont.setFontHeightInPoints((short)20);
+        contentWriteCellStyle.setWriteFont(contentWriteFont);
+        // 这个策略是 头是头的样式 内容是内容的样式 其他的策略可以自己实现
+        return new HorizontalCellStyleStrategy(headWriteCellStyle, contentWriteCellStyle);
     }
 
 }


### PR DESCRIPTION
修复动态表头时，内容单元格的样式不生效的bug #1339