### PR TITLE
提供一个动态合并策略给流式导出使用(也可以用于页导出)

### DIFF
--- a/src/main/java/com/alibaba/excel/write/merge/DynamicMergeStrategy.java
+++ b/src/main/java/com/alibaba/excel/write/merge/DynamicMergeStrategy.java
@@ -1,0 +1,192 @@
+package com.alibaba.excel.write.merge;
+
+import com.alibaba.excel.write.handler.RowWriteHandler;
+import com.alibaba.excel.write.handler.WorkbookWriteHandler;
+import com.alibaba.excel.write.metadata.WriteSheet;
+import com.alibaba.excel.write.metadata.holder.WriteSheetHolder;
+import com.alibaba.excel.write.metadata.holder.WriteTableHolder;
+import com.alibaba.excel.write.metadata.holder.WriteWorkbookHolder;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.util.CellRangeAddress;
+
+import java.util.*;
+
+/**
+ * The regions of the dynamic merge by realtime compute
+ *
+ * @author ZhiPeng Xu
+ */
+public class DynamicMergeStrategy implements RowWriteHandler, WorkbookWriteHandler {
+
+    /**
+     * Each one just use once at row dispose and sheet dispose
+     */
+    private final Map<Integer, List<SheetRegions>> sheetRegions = new HashMap<Integer, List<SheetRegions>>();
+
+    private Stack<CellRangeAddress> getRegions(final WriteSheet sheet) {
+
+        final int key = SheetRegions.hashCode(sheet);
+
+        final List<SheetRegions> sheets = this.sheetRegions.get(key);
+        if (sheets != null) {
+            for (final SheetRegions sheetRegions : sheets) {
+                if (sheet == sheetRegions.sheet) {
+                    return sheetRegions.regions;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private Stack<CellRangeAddress> getOrCreateRegions(final WriteSheet sheet) {
+
+        final int key = SheetRegions.hashCode(sheet);
+
+        List<SheetRegions> sheets = sheetRegions.get(key);
+        if (sheets != null) {
+            for (final SheetRegions sheetRegions : sheets) {
+                if (sheet == sheetRegions.sheet) {
+                    return sheetRegions.regions;
+                }
+            }
+        } else {
+            sheets = new ArrayList<SheetRegions>();
+            this.sheetRegions.put(key, sheets);
+        }
+
+        final SheetRegions sheetRegions = new SheetRegions(sheet);
+        sheets.add(sheetRegions);
+        return sheetRegions.regions;
+    }
+
+    /**
+     * append a region for merge
+     *
+     * @param region
+     * @param sheet
+     */
+    public void append(final CellRangeAddress region, WriteSheet sheet) {
+        final Stack<CellRangeAddress> regions = getOrCreateRegions(sheet);
+        regions.push(region);
+    }
+
+    /**
+     * merge
+     *
+     * @param holder
+     */
+    protected void merge(final WriteSheetHolder holder) {
+        final Stack<CellRangeAddress> regions = getRegions(holder.getWriteSheet());
+        if (regions != null) {
+            final Sheet sheet = holder.getSheet();
+            while (!regions.empty()) {
+                sheet.addMergedRegion(
+                    regions.pop()
+                );
+            }
+        }
+    }
+
+    // region do nothing...
+
+    @Override
+    public void beforeWorkbookCreate() {
+
+        // do nothing...
+    }
+
+    @Override
+    public void afterWorkbookCreate(
+        final WriteWorkbookHolder writeWorkbookHolder) {
+
+        // do nothing...
+    }
+
+    @Override
+    public void beforeRowCreate(
+        final WriteSheetHolder writeSheetHolder,
+        final WriteTableHolder writeTableHolder,
+        final Integer rowIndex,
+        final Integer relativeRowIndex,
+        final Boolean isHead) {
+
+        // do nothing...
+    }
+
+    @Override
+    public void afterRowCreate(
+        final WriteSheetHolder writeSheetHolder,
+        final WriteTableHolder writeTableHolder,
+        final Row row,
+        final Integer relativeRowIndex,
+        final Boolean isHead) {
+
+        // do nothing...
+    }
+
+    // endregion do nothing...
+
+    @Override
+    public void afterRowDispose(
+        final WriteSheetHolder writeSheetHolder,
+        final WriteTableHolder writeTableHolder,
+        final Row row,
+        final Integer relativeRowIndex,
+        final Boolean isHead) {
+
+        if (!isHead) {
+            merge(writeSheetHolder);
+        }
+    }
+
+    @Override
+    public void afterWorkbookDispose(
+        final WriteWorkbookHolder writeWorkbookHolder) {
+
+        final Map<Integer, WriteSheetHolder> indexes = writeWorkbookHolder.getHasBeenInitializedSheetIndexMap();
+        for (final Integer index : indexes.keySet()) {
+            final WriteSheetHolder writeSheetHolder = indexes.get(index);
+            merge(writeSheetHolder);
+        }
+
+        final Map<String, WriteSheetHolder> names = writeWorkbookHolder.getHasBeenInitializedSheetNameMap();
+        for (final String name : names.keySet()) {
+            final WriteSheetHolder writeSheetHolder = names.get(name);
+            merge(writeSheetHolder);
+        }
+
+        sheetRegions.clear();
+    }
+
+    private static class SheetRegions {
+
+        public static int hashCode(final WriteSheet sheet) {
+            int sheetNoHashCode = 0;
+            int sheetNameHashCode = 0;
+            if (sheet != null) {
+                if (sheet.getSheetNo() != null) {
+                    sheetNoHashCode = sheet.getSheetNo().hashCode();
+                }
+                if (sheet.getSheetName() != null) {
+                    sheetNameHashCode = sheet.getSheetName().hashCode();
+                }
+            }
+            return sheetNoHashCode ^ sheetNameHashCode;
+        }
+
+        private final WriteSheet sheet;
+
+        private final Stack<CellRangeAddress> regions = new Stack<CellRangeAddress>();
+
+        private SheetRegions(final WriteSheet sheet) {
+            this.sheet = sheet;
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode(sheet);
+        }
+    }
+}

--- a/src/test/java/com/alibaba/easyexcel/test/demo/write/DemoDynamicMergeData.java
+++ b/src/test/java/com/alibaba/easyexcel/test/demo/write/DemoDynamicMergeData.java
@@ -1,0 +1,24 @@
+package com.alibaba.easyexcel.test.demo.write;
+
+import com.alibaba.excel.annotation.ExcelProperty;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * 动态合并的数据类
+ *
+ * @author ZhiPeng Xu
+ */
+@Builder
+@Data
+public class DemoDynamicMergeData {
+
+    @ExcelProperty(value = "省", index = 0)
+    private final String province;
+
+    @ExcelProperty(value = "市", index = 1)
+    private final String city;
+
+    @ExcelProperty(value = "区", index = 2)
+    private final String district;
+}


### PR DESCRIPTION
- 对于层级数据结构, 当需要合并的子集行数不确定时, 可以使用本策略在写入行之后动态合并.
- 每个 WriteSheet 对应多个 CellRangeAddress
- 合并发生在 afterRowDispose, 以及时使用掉 CellRangeAddress 减少内存占用
- 合并发生在 afterWorkbookDispose, 主要用于每张数据表最后一次合并, 这次合并计算出来时行已经写入, 无法触发 afterRowDispose
- 由于使用 CellRangeAddress, 所以合并区域可以很灵活地编程实现, 包括同行多列, 同列多行, 多行多列, 将实际策略交给应用层, 这里只提供机制, 可以参考单元测试用例.

``` java
package com.alibaba.easyexcel.test.demo.write;

import com.alibaba.excel.annotation.ExcelProperty;
import lombok.Builder;
import lombok.Data;

/**
 * 动态合并的数据类
 *
 * @author ZhiPeng Xu
 */
@Builder
@Data
public class DemoDynamicMergeData {

    @ExcelProperty(value = "省", index = 0)
    private final String province;

    @ExcelProperty(value = "市", index = 1)
    private final String city;

    @ExcelProperty(value = "区", index = 2)
    private final String district;
}

```

![image](https://user-images.githubusercontent.com/5987706/89175052-84afc800-d5b9-11ea-8e19-f924cf710438.png)
