### PR TITLE
Fix the contentType issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ DEMO代码地址：[https://github.com/alibaba/easyexcel/blob/master/src/test/ja
     @GetMapping("download")
     public void download(HttpServletResponse response) throws IOException {
         // 这里注意 有同学反应使用swagger 会导致各种问题，请直接用浏览器或者用postman
-        response.setContentType("vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         response.setCharacterEncoding("utf-8");
         // 这里URLEncoder.encode可以防止中文乱码 当然和easyexcel没有关系
         String fileName = URLEncoder.encode("测试", "UTF-8").replaceAll("\\+", "%20");

--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ DEMO代码地址：[https://github.com/alibaba/easyexcel/blob/master/src/test/ja
     @GetMapping("download")
     public void download(HttpServletResponse response) throws IOException {
         // 这里注意 有同学反应使用swagger 会导致各种问题，请直接用浏览器或者用postman
-        response.setContentType("application/vnd.ms-excel");
+        response.setContentType("vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         response.setCharacterEncoding("utf-8");
         // 这里URLEncoder.encode可以防止中文乱码 当然和easyexcel没有关系
         String fileName = URLEncoder.encode("测试", "UTF-8").replaceAll("\\+", "%20");
         response.setHeader("Content-disposition", "attachment;filename*=utf-8''" + fileName + ".xlsx");
-        EasyExcel.write(response.getOutputStream(), DownloadData.class).sheet("模板").doWrite(data());
+        EasyExcel.write(response.getOutputStream(), DownloadData.class).excelType(ExcelTypeEnum.XLSX).sheet("模板").doWrite(data());
     }
 
     /**

--- a/src/test/java/com/alibaba/easyexcel/test/demo/web/WebTest.java
+++ b/src/test/java/com/alibaba/easyexcel/test/demo/web/WebTest.java
@@ -43,12 +43,12 @@ public class WebTest {
     @GetMapping("download")
     public void download(HttpServletResponse response) throws IOException {
         // 这里注意 有同学反应使用swagger 会导致各种问题，请直接用浏览器或者用postman
-        response.setContentType("application/vnd.ms-excel");
+        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         response.setCharacterEncoding("utf-8");
         // 这里URLEncoder.encode可以防止中文乱码 当然和easyexcel没有关系
         String fileName = URLEncoder.encode("测试", "UTF-8").replaceAll("\\+", "%20");
         response.setHeader("Content-disposition", "attachment;filename*=utf-8''" + fileName + ".xlsx");
-        EasyExcel.write(response.getOutputStream(), DownloadData.class).sheet("模板").doWrite(data());
+        EasyExcel.write(response.getOutputStream(), DownloadData.class).excelType(ExcelTypeEnum.XLSX).sheet("模板").doWrite(data());
     }
 
     /**
@@ -60,13 +60,13 @@ public class WebTest {
     public void downloadFailedUsingJson(HttpServletResponse response) throws IOException {
         // 这里注意 有同学反应使用swagger 会导致各种问题，请直接用浏览器或者用postman
         try {
-            response.setContentType("application/vnd.ms-excel");
+            response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
             response.setCharacterEncoding("utf-8");
             // 这里URLEncoder.encode可以防止中文乱码 当然和easyexcel没有关系
             String fileName = URLEncoder.encode("测试", "UTF-8").replaceAll("\\+", "%20");
             response.setHeader("Content-disposition", "attachment;filename*=utf-8''" + fileName + ".xlsx");
             // 这里需要设置不关闭流
-            EasyExcel.write(response.getOutputStream(), DownloadData.class).autoCloseStream(Boolean.FALSE).sheet("模板")
+            EasyExcel.write(response.getOutputStream(), DownloadData.class).excelType(ExcelTypeEnum.XLSX).autoCloseStream(Boolean.FALSE).sheet("模板")
                 .doWrite(data());
         } catch (Exception e) {
             // 重置response

--- a/src/test/java/com/alibaba/easyexcel/test/demo/web/WebTest.java
+++ b/src/test/java/com/alibaba/easyexcel/test/demo/web/WebTest.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.alibaba.excel.EasyExcel;
+import com.alibaba.excel.support.ExcelTypeEnum;
 import com.alibaba.fastjson.JSON;
 
 /**


### PR DESCRIPTION
Raise the PR to fix the sample issue by incorrect content type.

By given sample, we will get a xls type excel even set excelType(ExcelTypeEnum.XLSX), which will open with an alert even the file encoding is based on xlsx. 
"The file format and extension of 'xxx' don't match. The file could be corrupted of unsafe. Unless you trust its source, don't open it. Do you want to open it anyway?"
![image](https://user-images.githubusercontent.com/3264250/92856610-37c7d880-f426-11ea-9761-36a629696834.png)

The root cause is from incorrect content type. it will be fine if set the content type based on xlsx as below
response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")

Reference:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types

.xls | Microsoft Excel | application/vnd.ms-excel
-- | -- | --
.xlsx | Microsoft Excel (OpenXML) | application/vnd.openxmlformats-officedocument.spreadsheetml.sheet

