### PR TITLE
fix flaytests in SimpleDataTest

### DIFF
--- a/src/test/java/com/alibaba/easyexcel/test/core/simple/SimpleDataTest.java
+++ b/src/test/java/com/alibaba/easyexcel/test/core/simple/SimpleDataTest.java
@@ -62,6 +62,7 @@ public class SimpleDataTest {
 
     private void synchronousRead(File file) {
         // Synchronous read file
+        EasyExcel.write(file, SimpleData.class).sheet().doWrite(data());
         List<Object> list = EasyExcel.read(file).head(SimpleData.class).sheet().doReadSync();
         Assert.assertEquals(list.size(), 10);
         Assert.assertTrue(list.get(0) instanceof SimpleData);


### PR DESCRIPTION
Two test cases: **t03SynchronousRead07** and **t04SynchronousRead03** are flaky tests and caused by test-order dependency.
Take t04SynchronousRead03 for instance, if we run t04SynchronousRead03 before t02ReadAndWrite03, it will raise ExcelAnalysisException (error log attached). So we would better to write the file before we initialized the list in synchronousRead() 

Flaky tests found by https://github.com/idflakies/idflakies and Professor Darko Marinov at UIUC (http://mir.cs.illinois.edu/marinov/).

Error Log: 
```
t03SynchronousRead07(com.alibaba.easyexcel.test.core.simple.SimpleDataTest)  Time elapsed: 0.138 sec  <<< ERROR!
com.alibaba.excel.exception.ExcelAnalysisException: File /Users/zhouxiangcai/Documents/GitHub/easyexcel/target/test-classes/simple07.xlsx not exists.
	at com.alibaba.excel.support.ExcelTypeEnum.valueOf(ExcelTypeEnum.java:47)
	at com.alibaba.excel.analysis.ExcelAnalyserImpl.choiceExcelExecutor(ExcelAnalyserImpl.java:62)
	at com.alibaba.excel.analysis.ExcelAnalyserImpl.<init>(ExcelAnalyserImpl.java:51)
	at com.alibaba.excel.ExcelReader.<init>(ExcelReader.java:145)
	at com.alibaba.excel.read.builder.ExcelReaderBuilder.build(ExcelReaderBuilder.java:193)
	at com.alibaba.excel.read.builder.ExcelReaderBuilder.sheet(ExcelReaderBuilder.java:229)
	at com.alibaba.excel.read.builder.ExcelReaderBuilder.sheet(ExcelReaderBuilder.java:217)
	at com.alibaba.easyexcel.test.core.simple.SimpleDataTest.synchronousRead(SimpleDataTest.java:66)
	at com.alibaba.easyexcel.test.core.simple.SimpleDataTest.t03SynchronousRead07(SimpleDataTest.java:49)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
```