### PR TITLE
Fix bug list classType not same with head type when write

### DIFF
--- a/src/main/java/com/alibaba/excel/write/executor/ExcelWriteAddExecutor.java
+++ b/src/main/java/com/alibaba/excel/write/executor/ExcelWriteAddExecutor.java
@@ -149,7 +149,6 @@ public class ExcelWriteAddExecutor extends AbstractExcelWriteExecutor {
         Map<String, Field> ignoreMap = writeContext.currentWriteHolder().excelWriteHeadProperty().getIgnoreMap();
         initSortedAllFiledMapFieldList(oneRowData.getClass(), sortedAllFiledMap);
         for (Map.Entry<Integer, Field> entry : sortedAllFiledMap.entrySet()) {
-            // cellIndex = entry.getKey();
             Field field = entry.getValue();
             String filedName = field.getName();
             boolean uselessData = !beanMap.containsKey(filedName) || beanMapHandledSet.contains(filedName)

--- a/src/main/java/com/alibaba/excel/write/executor/ExcelWriteAddExecutor.java
+++ b/src/main/java/com/alibaba/excel/write/executor/ExcelWriteAddExecutor.java
@@ -1,16 +1,5 @@
 package com.alibaba.excel.write.executor;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
-
-import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.Row;
-
 import com.alibaba.excel.context.WriteContext;
 import com.alibaba.excel.enums.HeadKindEnum;
 import com.alibaba.excel.metadata.CellData;
@@ -20,13 +9,15 @@ import com.alibaba.excel.util.ClassUtils;
 import com.alibaba.excel.util.CollectionUtils;
 import com.alibaba.excel.util.WorkBookUtil;
 import com.alibaba.excel.util.WriteHandlerUtils;
-import com.alibaba.excel.write.metadata.WriteWorkbook;
-import com.alibaba.excel.write.metadata.holder.AbstractWriteHolder;
 import com.alibaba.excel.write.metadata.holder.WriteHolder;
 import com.alibaba.excel.write.metadata.holder.WriteSheetHolder;
 import com.alibaba.excel.write.metadata.holder.WriteWorkbookHolder;
-
 import net.sf.cglib.beans.BeanMap;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+
+import java.lang.reflect.Field;
+import java.util.*;
 
 /**
  * Add the data into excel
@@ -59,7 +50,7 @@ public class ExcelWriteAddExecutor extends AbstractExcelWriteExecutor {
     }
 
     private void addOneRowOfDataToExcel(Object oneRowData, int n, int relativeRowIndex,
-        Map<Integer, Field> sortedAllFiledMap) {
+                                        Map<Integer, Field> sortedAllFiledMap) {
         if (oneRowData == null) {
             return;
         }
@@ -103,7 +94,7 @@ public class ExcelWriteAddExecutor extends AbstractExcelWriteExecutor {
     }
 
     private void doAddBasicTypeToExcel(List<Object> oneRowData, Head head, Row row, int relativeRowIndex, int dataIndex,
-        int cellIndex) {
+                                       int cellIndex) {
         WriteHandlerUtils.beforeCellCreate(writeContext, row, head, cellIndex, relativeRowIndex, Boolean.FALSE);
         Cell cell = WorkBookUtil.createCell(row, cellIndex);
         WriteHandlerUtils.afterCellCreate(writeContext, cell, head, relativeRowIndex, Boolean.FALSE);
@@ -114,7 +105,7 @@ public class ExcelWriteAddExecutor extends AbstractExcelWriteExecutor {
     }
 
     private void addJavaObjectToExcel(Object oneRowData, Row row, int relativeRowIndex,
-        Map<Integer, Field> sortedAllFiledMap) {
+                                      Map<Integer, Field> sortedAllFiledMap) {
         WriteHolder currentWriteHolder = writeContext.currentWriteHolder();
         BeanMap beanMap = BeanMap.create(oneRowData);
         Set<String> beanMapHandledSet = new HashSet<String>();
@@ -141,6 +132,7 @@ public class ExcelWriteAddExecutor extends AbstractExcelWriteExecutor {
                 WriteHandlerUtils.afterCellDispose(writeContext, cellData, cell, head, relativeRowIndex, Boolean.FALSE);
                 beanMapHandledSet.add(name);
             }
+            cellIndex++;
         }
         // Finish
         if (beanMapHandledSet.size() == beanMap.size()) {
@@ -157,8 +149,8 @@ public class ExcelWriteAddExecutor extends AbstractExcelWriteExecutor {
                 continue;
             }
             Object value = beanMap.get(filedName);
-            WriteHandlerUtils.beforeCellCreate(writeContext, row, null, cellIndex++, relativeRowIndex, Boolean.FALSE);
-            Cell cell = WorkBookUtil.createCell(row, cellIndex);
+            WriteHandlerUtils.beforeCellCreate(writeContext, row, null, cellIndex, relativeRowIndex, Boolean.FALSE);
+            Cell cell = WorkBookUtil.createCell(row, cellIndex++);
             WriteHandlerUtils.afterCellCreate(writeContext, cell, null, relativeRowIndex, Boolean.FALSE);
             CellData cellData = converterAndSet(currentWriteHolder, value == null ? null : value.getClass(), cell,
                 value, null, null, relativeRowIndex);

--- a/src/main/java/com/alibaba/excel/write/executor/ExcelWriteAddExecutor.java
+++ b/src/main/java/com/alibaba/excel/write/executor/ExcelWriteAddExecutor.java
@@ -149,7 +149,7 @@ public class ExcelWriteAddExecutor extends AbstractExcelWriteExecutor {
         Map<String, Field> ignoreMap = writeContext.currentWriteHolder().excelWriteHeadProperty().getIgnoreMap();
         initSortedAllFiledMapFieldList(oneRowData.getClass(), sortedAllFiledMap);
         for (Map.Entry<Integer, Field> entry : sortedAllFiledMap.entrySet()) {
-            cellIndex = entry.getKey();
+            // cellIndex = entry.getKey();
             Field field = entry.getValue();
             String filedName = field.getName();
             boolean uselessData = !beanMap.containsKey(filedName) || beanMapHandledSet.contains(filedName)
@@ -158,7 +158,7 @@ public class ExcelWriteAddExecutor extends AbstractExcelWriteExecutor {
                 continue;
             }
             Object value = beanMap.get(filedName);
-            WriteHandlerUtils.beforeCellCreate(writeContext, row, null, cellIndex, relativeRowIndex, Boolean.FALSE);
+            WriteHandlerUtils.beforeCellCreate(writeContext, row, null, cellIndex++, relativeRowIndex, Boolean.FALSE);
             Cell cell = WorkBookUtil.createCell(row, cellIndex);
             WriteHandlerUtils.afterCellCreate(writeContext, cell, null, relativeRowIndex, Boolean.FALSE);
             CellData cellData = converterAndSet(currentWriteHolder, value == null ? null : value.getClass(), cell,

--- a/src/main/java/com/alibaba/excel/write/executor/ExcelWriteAddExecutor.java
+++ b/src/main/java/com/alibaba/excel/write/executor/ExcelWriteAddExecutor.java
@@ -17,7 +17,12 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
 
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * Add the data into excel

--- a/src/test/java/com/alibaba/easyexcel/test/temp/bug/DataType.java
+++ b/src/test/java/com/alibaba/easyexcel/test/temp/bug/DataType.java
@@ -1,0 +1,33 @@
+package com.alibaba.easyexcel.test.temp.bug;
+
+import com.alibaba.excel.annotation.ExcelProperty;
+import lombok.Data;
+
+/**
+ * @author jiaosong
+ * @desc
+ * @date 2021/4/6
+ */
+@Data
+public class DataType {
+    /**
+     * 任务id
+     */
+    @ExcelProperty("任务ID")
+    private Integer id;
+
+    @ExcelProperty("多余字段1")
+    private String firstSurplus;
+
+    @ExcelProperty("多余字段2")
+    private String secSurplus;
+
+    @ExcelProperty("多余字段3")
+    private String thirdSurplus;
+
+    @ExcelProperty(value = "备注1")
+    private String firstRemark;
+
+    @ExcelProperty(value = "备注2")
+    private String secRemark;
+}

--- a/src/test/java/com/alibaba/easyexcel/test/temp/bug/ExcelCreat.java
+++ b/src/test/java/com/alibaba/easyexcel/test/temp/bug/ExcelCreat.java
@@ -1,0 +1,38 @@
+package com.alibaba.easyexcel.test.temp.bug;
+
+import com.alibaba.excel.EasyExcel;
+import com.alibaba.excel.ExcelWriter;
+import com.alibaba.excel.write.metadata.WriteSheet;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author jiaosong
+ * @desc
+ * @date 2020/4/6
+ */
+public class ExcelCreat {
+
+
+    public static void main(String[] args) throws FileNotFoundException {
+        List<DataType> data = getData();
+        ExcelWriter excelWriter = null;
+        excelWriter = EasyExcel.write(new FileOutputStream("all.xlsx")).build();
+        WriteSheet writeSheet = EasyExcel.writerSheet(1, "test")
+            .head(HeadType.class)
+            .build();
+        excelWriter.write(data, writeSheet);
+        excelWriter.finish();
+    }
+
+    private static List<DataType> getData() {
+        DataType vo = new DataType();
+        vo.setId(738);
+        vo.setFirstRemark("1222");
+        vo.setSecRemark("22222");
+        return Collections.singletonList(vo);
+    }
+}

--- a/src/test/java/com/alibaba/easyexcel/test/temp/bug/HeadType.java
+++ b/src/test/java/com/alibaba/easyexcel/test/temp/bug/HeadType.java
@@ -1,0 +1,28 @@
+package com.alibaba.easyexcel.test.temp.bug;
+
+import com.alibaba.excel.annotation.ExcelProperty;
+import lombok.Data;
+
+/**
+ * @author jiaosong
+ * @desc
+ * @date 2021/4/6
+ */
+@Data
+public class HeadType {
+
+
+    /**
+     * 任务id
+     */
+    @ExcelProperty("任务ID")
+    private Integer id;
+
+
+    @ExcelProperty(value = "备注1")
+    private String firstRemark;
+
+    @ExcelProperty(value = "备注2")
+    private String secRemark;
+
+}


### PR DESCRIPTION
issue#1870
解决了写入时 list的泛型与指定的head classType不一致时，导致部分字段被空cell覆盖的问题
test的代码在com/alibaba/easyexcel/test/temp/bug 包下