### PR TITLE
Try to fix #1405

### DIFF
--- a/src/main/java/com/alibaba/excel/write/executor/AbstractExcelWriteExecutor.java
+++ b/src/main/java/com/alibaba/excel/write/executor/AbstractExcelWriteExecutor.java
@@ -45,7 +45,7 @@ public abstract class AbstractExcelWriteExecutor implements ExcelWriteExecutor {
             if (currentWriteHolder.globalConfiguration().getAutoTrim()) {
                 value = ((String) value).trim();
             }
-
+            // Fix issue https://github.com/alibaba/easyexcel/issues/1405
             // Check that if current string data type can be converted to integer or double type.
             if (Pattern.matches(INTEGER_REGEX, (String) value)) {
                 clazz = Integer.class;


### PR DESCRIPTION
Try to fix #1405 , which exporting sheet with string type 0.00 value, thus it cannot be maniputed as operator in Excel software.

Add type check before writing to .xlsx. Use final variable to minimize the overhead of casting and creating `String` type variable. All existed test passed. No new test yet.