### PR TITLE
Try to fix issue #1899

### DIFF
--- a/src/main/java/com/alibaba/excel/write/builder/ExcelWriterBuilder.java
+++ b/src/main/java/com/alibaba/excel/write/builder/ExcelWriterBuilder.java
@@ -3,6 +3,8 @@ package com.alibaba.excel.write.builder;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.alibaba.excel.ExcelWriter;
 import com.alibaba.excel.support.ExcelTypeEnum;
@@ -83,7 +85,23 @@ public class ExcelWriterBuilder extends AbstractExcelWriterParameterBuilder<Exce
     }
 
     public ExcelWriterBuilder excelType(ExcelTypeEnum excelType) {
+        // try to fix issue #1899
+        // https://github.com/alibaba/easyexcel/issues/1899
+        // use regex to match file name with xls
+        String regXLS = ".*(.xls|.XLS)$";
         writeWorkbook.setExcelType(excelType);
+        if (writeWorkbook.getFile() != null) {
+            String fileName = writeWorkbook.getFile().getName();
+            Pattern pattern = Pattern.compile(regXLS);
+            Matcher matcher = pattern.matcher(fileName);
+            if (matcher.matches()) {
+                // if current exceltype is XLSX, then change the file name with "xlsx" at the end
+                if (excelType == ExcelTypeEnum.XLSX) {
+                    fileName = fileName.substring(0, fileName.length() - 3) + "xlsx";
+                }
+            }
+            file(fileName);
+        }
         return this;
     }
 


### PR DESCRIPTION
Try to fix #1899 , which can't set the type of the download file to be `xlsx` file.

Add file name check after set the `excelType`. After changing the type, judge the suffix of the file name. If the file is of the `xls` type, and the changed excelType is `XLSX`, then use the `file()` function to change the suffix of the file to xlsx 