### PR TITLE
feat: 支持写excel实体对象含有列表类型属性字段，可进行动态写入，可支持原有类相关注解对动态列做设置

### DIFF
--- a/easyexcel-core/src/main/java/com/alibaba/excel/annotation/ExcelDynamicClass.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/annotation/ExcelDynamicClass.java
@@ -1,0 +1,17 @@
+package com.alibaba.excel.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author helei01_gza
+ * @since 2022/2/11
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface ExcelDynamicClass {
+}

--- a/easyexcel-core/src/main/java/com/alibaba/excel/annotation/ExcelDynamicColumn.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/annotation/ExcelDynamicColumn.java
@@ -1,0 +1,17 @@
+package com.alibaba.excel.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author hooray
+ * @since 2022/2/10
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface ExcelDynamicColumn {
+}

--- a/easyexcel-core/src/main/java/com/alibaba/excel/context/WriteContext.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/context/WriteContext.java
@@ -1,6 +1,7 @@
 package com.alibaba.excel.context;
 
 import java.io.OutputStream;
+import java.util.Collection;
 
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -22,11 +23,25 @@ public interface WriteContext {
     /**
      * If the current sheet already exists, select it; if not, create it
      *
-     * @param writeSheet
-     *            Current sheet
+     * @param writeSheet Current sheet
      * @param writeType
      */
     void currentSheet(WriteSheet writeSheet, WriteTypeEnum writeType);
+
+    /**
+     * Dynamically construct head from data
+     *
+     * @param writeSheet Current sheet
+     * @param data add data
+     */
+    void addCurrentSheet(WriteSheet writeSheet, Collection<?> data);
+
+    /**
+     * is dynamic excel
+     *
+     * @return
+     */
+    boolean isDynamic();
 
     /**
      * If the current table already exists, select it; if not, create it

--- a/easyexcel-core/src/main/java/com/alibaba/excel/metadata/Head.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/metadata/Head.java
@@ -22,7 +22,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @EqualsAndHashCode
-public class Head {
+public class Head implements Cloneable {
     /**
      * Column index of head
      */
@@ -67,7 +67,7 @@ public class Head {
     private FontProperty headFontProperty;
 
     public Head(Integer columnIndex, Field field, String fieldName, List<String> headNameList, Boolean forceIndex,
-        Boolean forceName) {
+                Boolean forceName) {
         this.columnIndex = columnIndex;
         this.field = field;
         this.fieldName = fieldName;
@@ -83,5 +83,10 @@ public class Head {
         }
         this.forceIndex = forceIndex;
         this.forceName = forceName;
+    }
+
+    @Override
+    public Head clone() throws CloneNotSupportedException {
+        return (Head) super.clone();
     }
 }

--- a/easyexcel-core/src/main/java/com/alibaba/excel/util/TypeUtils.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/util/TypeUtils.java
@@ -1,0 +1,122 @@
+package com.alibaba.excel.util;
+
+import org.ehcache.impl.internal.classes.commonslang.ArrayUtils;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+
+/**
+ * @author hooray
+ * @since 2022/2/11
+ */
+public class TypeUtils {
+
+    /**
+     * 获得给定类的第一个泛型参数
+     *
+     * @param type 被检查的类型，必须是已经确定泛型类型的类型
+     * @return {@link Type}，可能为{@code null}
+     */
+    public static Type getTypeArgument(Type type) {
+        return getTypeArgument(type, 0);
+    }
+
+    /**
+     * 获得给定类的泛型参数
+     *
+     * @param type  被检查的类型，必须是已经确定泛型类型的类
+     * @param index 泛型类型的索引号，即第几个泛型类型
+     * @return {@link Type}
+     */
+    public static Type getTypeArgument(Type type, int index) {
+        final Type[] typeArguments = getTypeArguments(type);
+        if (null != typeArguments && typeArguments.length > index) {
+            return typeArguments[index];
+        }
+        return null;
+    }
+
+    /**
+     * 获得指定类型中所有泛型参数类型，例如：
+     *
+     * <pre>
+     * class A&lt;T&gt;
+     * class B extends A&lt;String&gt;
+     * </pre>
+     * <p>
+     * 通过此方法，传入B.class即可得到String
+     *
+     * @param type 指定类型
+     * @return 所有泛型参数类型
+     */
+    public static Type[] getTypeArguments(Type type) {
+        if (null == type) {
+            return null;
+        }
+
+        final ParameterizedType parameterizedType = toParameterizedType(type);
+        return (null == parameterizedType) ? null : parameterizedType.getActualTypeArguments();
+    }
+
+    /**
+     * 将{@link Type} 转换为{@link ParameterizedType}<br>
+     * {@link ParameterizedType}用于获取当前类或父类中泛型参数化后的类型<br>
+     * 一般用于获取泛型参数具体的参数类型，例如：
+     *
+     * <pre>
+     * class A&lt;T&gt;
+     * class B extends A&lt;String&gt;
+     * </pre>
+     * <p>
+     * 通过此方法，传入B.class即可得到B{@link ParameterizedType}，从而获取到String
+     *
+     * @param type {@link Type}
+     * @return {@link ParameterizedType}
+     * @since 4.5.2
+     */
+    public static ParameterizedType toParameterizedType(Type type) {
+        ParameterizedType result = null;
+        if (type instanceof ParameterizedType) {
+            result = (ParameterizedType) type;
+        } else if (type instanceof Class) {
+            final Class<?> clazz = (Class<?>) type;
+            Type genericSuper = clazz.getGenericSuperclass();
+            if (null == genericSuper || Object.class.equals(genericSuper)) {
+                // 如果类没有父类，而是实现一些定义好的泛型接口，则取接口的Type
+                final Type[] genericInterfaces = clazz.getGenericInterfaces();
+                if (!ArrayUtils.isEmpty(genericInterfaces)) {
+                    // 默认取第一个实现接口的泛型Type
+                    genericSuper = genericInterfaces[0];
+                }
+            }
+            result = toParameterizedType(genericSuper);
+        }
+        return result;
+    }
+
+    /**
+     * 获得Type对应的原始类
+     *
+     * @param type {@link Type}
+     * @return 原始类，如果无法获取原始类，返回{@code null}
+     */
+    public static Class<?> getClass(Type type) {
+        if (null != type) {
+            if (type instanceof Class) {
+                return (Class<?>) type;
+            } else if (type instanceof ParameterizedType) {
+                return (Class<?>) ((ParameterizedType) type).getRawType();
+            } else if (type instanceof TypeVariable) {
+                return (Class<?>) ((TypeVariable<?>) type).getBounds()[0];
+            } else if (type instanceof WildcardType) {
+                final Type[] upperBounds = ((WildcardType) type).getUpperBounds();
+                if (upperBounds.length == 1) {
+                    return getClass(upperBounds[0]);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/easyexcel-core/src/main/java/com/alibaba/excel/write/ExcelBuilderImpl.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/write/ExcelBuilderImpl.java
@@ -1,7 +1,5 @@
 package com.alibaba.excel.write;
 
-import java.util.Collection;
-
 import com.alibaba.excel.context.WriteContext;
 import com.alibaba.excel.context.WriteContextImpl;
 import com.alibaba.excel.enums.WriteTypeEnum;
@@ -14,8 +12,9 @@ import com.alibaba.excel.write.metadata.WriteSheet;
 import com.alibaba.excel.write.metadata.WriteTable;
 import com.alibaba.excel.write.metadata.WriteWorkbook;
 import com.alibaba.excel.write.metadata.fill.FillConfig;
-
 import org.apache.poi.ss.util.CellRangeAddress;
+
+import java.util.Collection;
 
 /**
  * @author jipengfei
@@ -51,7 +50,7 @@ public class ExcelBuilderImpl implements ExcelBuilder {
     @Override
     public void addContent(Collection<?> data, WriteSheet writeSheet, WriteTable writeTable) {
         try {
-            context.currentSheet(writeSheet, WriteTypeEnum.ADD);
+            context.addCurrentSheet(writeSheet, data);
             context.currentTable(writeTable);
             if (excelWriteAddExecutor == null) {
                 excelWriteAddExecutor = new ExcelWriteAddExecutor(context);

--- a/easyexcel-core/src/test/java/com/alibaba/easyexcel/test/demo/write/DemoDynamicData.java
+++ b/easyexcel-core/src/test/java/com/alibaba/easyexcel/test/demo/write/DemoDynamicData.java
@@ -1,0 +1,83 @@
+package com.alibaba.easyexcel.test.demo.write;
+
+import com.alibaba.excel.annotation.ExcelDynamicClass;
+import com.alibaba.excel.annotation.ExcelDynamicColumn;
+import com.alibaba.excel.annotation.ExcelProperty;
+import com.alibaba.excel.annotation.format.DateTimeFormat;
+import com.alibaba.excel.annotation.format.NumberFormat;
+import com.alibaba.excel.annotation.write.style.ContentFontStyle;
+import com.alibaba.excel.annotation.write.style.ContentStyle;
+import com.alibaba.excel.annotation.write.style.HeadFontStyle;
+import com.alibaba.excel.annotation.write.style.HeadStyle;
+import com.alibaba.excel.enums.poi.FillPatternTypeEnum;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * @author helei01_gza
+ * @since 2022/2/11
+ */
+@Getter
+@Setter
+@EqualsAndHashCode
+// 头背景设置成红色 IndexedColors.RED.getIndex()
+@HeadStyle(fillPatternType = FillPatternTypeEnum.SOLID_FOREGROUND, fillForegroundColor = 10)
+// 头字体设置成20
+@HeadFontStyle(fontHeightInPoints = 20)
+// 内容的背景设置成绿色 IndexedColors.GREEN.getIndex()
+@ContentStyle(fillPatternType = FillPatternTypeEnum.SOLID_FOREGROUND, fillForegroundColor = 17)
+// 内容字体设置成20
+@ContentFontStyle(fontHeightInPoints = 20)
+public class DemoDynamicData {
+
+    @ExcelProperty("字符串标题")
+    private String string;
+
+    @ExcelProperty("日期标题")
+    private Date date;
+
+    @ExcelDynamicColumn
+    private DynamicData[] dynamicArray;
+
+    @ExcelDynamicColumn
+    private List<DynamicData> dynamicDataList;
+
+    @ExcelProperty("数字标题")
+    private Double doubleData;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode
+    @ExcelDynamicClass
+    // 头背景设置成红色 IndexedColors.RED.getIndex()
+    @HeadStyle(fillPatternType = FillPatternTypeEnum.SOLID_FOREGROUND, fillForegroundColor = 10)
+// 头字体设置成20
+    @HeadFontStyle(fontHeightInPoints = 20)
+// 内容的背景设置成绿色 IndexedColors.GREEN.getIndex()
+    @ContentStyle(fillPatternType = FillPatternTypeEnum.SOLID_FOREGROUND, fillForegroundColor = 17)
+// 内容字体设置成20
+    @ContentFontStyle(fontHeightInPoints = 20)
+    public static class DynamicData {
+        // 字符串的头背景设置成粉红 IndexedColors.PINK.getIndex()
+        @HeadStyle(fillPatternType = FillPatternTypeEnum.SOLID_FOREGROUND, fillForegroundColor = 14)
+        // 字符串的头字体设置成20
+        @HeadFontStyle(fontHeightInPoints = 30)
+        // 字符串的内容的背景设置成天蓝 IndexedColors.SKY_BLUE.getIndex()
+        @ContentStyle(fillPatternType = FillPatternTypeEnum.SOLID_FOREGROUND, fillForegroundColor = 40)
+        // 字符串的内容字体设置成20
+        @ContentFontStyle(fontHeightInPoints = 30)
+        @ExcelProperty("动态字符串标题")
+        private String string;
+
+        @NumberFormat("#.##%")
+        @ExcelProperty("动态数字标题")
+        private Double doubleData;
+    }
+
+}
+
+

--- a/easyexcel-core/src/test/java/com/alibaba/easyexcel/test/demo/write/WriteTest.java
+++ b/easyexcel-core/src/test/java/com/alibaba/easyexcel/test/demo/write/WriteTest.java
@@ -1,14 +1,5 @@
 package com.alibaba.easyexcel.test.demo.write;
 
-import java.io.File;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import com.alibaba.easyexcel.test.util.TestFileUtil;
 import com.alibaba.excel.EasyExcel;
 import com.alibaba.excel.ExcelWriter;
@@ -39,7 +30,6 @@ import com.alibaba.excel.write.metadata.style.WriteCellStyle;
 import com.alibaba.excel.write.metadata.style.WriteFont;
 import com.alibaba.excel.write.style.HorizontalCellStyleStrategy;
 import com.alibaba.excel.write.style.column.LongestMatchColumnWidthStyleStrategy;
-
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.FillPatternType;
@@ -48,6 +38,16 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * 写的常见写法
@@ -269,7 +269,7 @@ public class WriteTest {
 
         String imagePath = TestFileUtil.getPath() + "converter" + File.separator + "img.jpg";
         try (InputStream inputStream = FileUtils.openInputStream(new File(imagePath))) {
-            List<ImageDemoData> list =  ListUtils.newArrayList();
+            List<ImageDemoData> list = ListUtils.newArrayList();
             ImageDemoData imageDemoData = new ImageDemoData();
             list.add(imageDemoData);
             // 放入五种类型的图片 实际使用只要选一种即可
@@ -477,7 +477,7 @@ public class WriteTest {
         // 背景设置为红色
         headWriteCellStyle.setFillForegroundColor(IndexedColors.RED.getIndex());
         WriteFont headWriteFont = new WriteFont();
-        headWriteFont.setFontHeightInPoints((short)20);
+        headWriteFont.setFontHeightInPoints((short) 20);
         headWriteCellStyle.setWriteFont(headWriteFont);
         // 内容的策略
         WriteCellStyle contentWriteCellStyle = new WriteCellStyle();
@@ -487,7 +487,7 @@ public class WriteTest {
         contentWriteCellStyle.setFillForegroundColor(IndexedColors.GREEN.getIndex());
         WriteFont contentWriteFont = new WriteFont();
         // 字体大小
-        contentWriteFont.setFontHeightInPoints((short)20);
+        contentWriteFont.setFontHeightInPoints((short) 20);
         contentWriteCellStyle.setWriteFont(contentWriteFont);
         // 这个策略是 头是头的样式 内容是内容的样式 其他的策略可以自己实现
         HorizontalCellStyleStrategy horizontalCellStyleStrategy =
@@ -729,6 +729,17 @@ public class WriteTest {
         EasyExcel.write(fileName).head(head()).sheet("模板").doWrite(dataList());
     }
 
+    @Test
+    public void dynamicColumnWrite() {
+        String fileName = TestFileUtil.getPath() + "dynamicColumnWrite" + System.currentTimeMillis() + ".xlsx";
+        // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
+        // 如果这里想使用03 则 传入excelType参数即可
+        // 分页查询数据
+        EasyExcel.write(fileName, DemoDynamicData.class)
+            .sheet("模板")
+            .doWrite(dynamicData());
+    }
+
     private List<LongestMatchColumnWidthData> dataLong() {
         List<LongestMatchColumnWidthData> list = ListUtils.newArrayList();
         for (int i = 0; i < 10; i++) {
@@ -793,4 +804,32 @@ public class WriteTest {
         return list;
     }
 
+    private List<DemoDynamicData> dynamicData() {
+        List<DemoDynamicData> list = ListUtils.newArrayList();
+        for (int i = 0; i < 10; i++) {
+            DemoDynamicData data = new DemoDynamicData();
+            data.setString("字符串" + i);
+            data.setDate(new Date());
+            data.setDoubleData(0.56);
+
+            DemoDynamicData.DynamicData dynamicData = new DemoDynamicData.DynamicData();
+            dynamicData.setString("动态字符串" + i);
+            dynamicData.setDoubleData(0.57);
+            data.setDynamicDataList(Arrays.asList(dynamicData, dynamicData));
+            data.setDynamicArray(new DemoDynamicData.DynamicData[]{dynamicData, dynamicData});
+            list.add(data);
+        }
+        DemoDynamicData data = new DemoDynamicData();
+        data.setString("字符串" + 11);
+        data.setDate(new Date());
+        data.setDoubleData(0.56);
+
+        DemoDynamicData.DynamicData dynamicData = new DemoDynamicData.DynamicData();
+        dynamicData.setString("动态字符串" + 11);
+        dynamicData.setDoubleData(0.57);
+        data.setDynamicDataList(Arrays.asList(dynamicData, dynamicData, dynamicData));
+        data.setDynamicArray(new DemoDynamicData.DynamicData[]{dynamicData});
+        list.add(data);
+        return list;
+    }
 }


### PR DESCRIPTION
1. 按照指定class写时，如果该实体成员属性中含有集合（Collection) 类型 或 数组类型 （Array），使用了@ExcelDynamicColumn在成员属性上，并且在对应的类上用@ExcelDynamicClass标注后，即可做动态列支持。
2. 目前仅支持集合（Collection) 类型 或 数组类型 （Array）动态扩展，集合的泛型类也不能是基础类型和非普通的类（接口、抽象类等）。
3. 该动态列，支持原有类上的所有样式注解，但目前还不支持动态表头名。
