### PR TITLE
BUG: Invalid when formatting is set on cells with formula values

### DIFF
--- a/src/main/java/com/alibaba/excel/analysis/v03/handlers/FormulaRecordHandler.java
+++ b/src/main/java/com/alibaba/excel/analysis/v03/handlers/FormulaRecordHandler.java
@@ -64,6 +64,7 @@ public class FormulaRecordHandler extends AbstractXlsRecordHandler implements Ig
                 dataFormatData.setFormat(BuiltinFormats.getBuiltinFormat(dataFormatData.getIndex(),
                     xlsReadContext.xlsReadWorkbookHolder().getFormatTrackingHSSFListener().getFormatString(frec),
                     xlsReadContext.readSheetHolder().getGlobalConfiguration().getLocale()));
+                tempCellData.setDataFormatData(dataFormatData);
                 cellMap.put((int)frec.getColumn(), tempCellData);
                 break;
             case ERROR:


### PR DESCRIPTION
当单元格的值来自于公式，又给单元格设置了格式转换，我们期望读取到的值是转换后的值，但是由于代码手误，忘记将格式转换的信息设置回去了，导致读取出来的结果是不是格式转换后的值。所以帮忙加了上去，已经在自己生产使用了。希望作者merge,方便后续升级。