### PR TITLE
完善了时间format输出

### DIFF
--- a/src/main/java/com/alibaba/excel/util/DateUtils.java
+++ b/src/main/java/com/alibaba/excel/util/DateUtils.java
@@ -45,11 +45,12 @@ public class DateUtils {
     private static final Pattern date_ptrn6 = Pattern.compile("(年|月|日|时|分|秒)+");
 
     public static final String DATE_FORMAT_10 = "yyyy-MM-dd";
-    public static final String DATE_FORMAT_14 = "yyyyMMddHHmmss";
     public static final String DATE_FORMAT_16 = "yyyy-MM-dd HH:mm";
-    public static final String DATE_FORMAT_16_FORWARD_SLASH = "yyyy/MM/dd HH:mm";
-    public static final String DATE_FORMAT_17 = "yyyyMMdd HH:mm:ss";
     public static final String DATE_FORMAT_19 = "yyyy-MM-dd HH:mm:ss";
+    public static final String DATE_FORMAT_14 = "yyyyMMddHHmmss";
+    public static final String DATE_FORMAT_17 = "yyyyMMdd HH:mm:ss";
+    public static final String DATE_FORMAT_10_FORWARD_SLASH = "yyyy/MM/dd";
+    public static final String DATE_FORMAT_16_FORWARD_SLASH = "yyyy/MM/dd HH:mm";
     public static final String DATE_FORMAT_19_FORWARD_SLASH = "yyyy/MM/dd HH:mm:ss";
     private static final String MINUS = "-";
 
@@ -102,6 +103,9 @@ public class DateUtils {
         return parseDate(dateString, switchDateFormat(dateString));
     }
 
+    public static boolean isNumber(char a){
+        return a>=30&&a<=39;
+    }
     /**
      * switch date format
      *
@@ -109,29 +113,47 @@ public class DateUtils {
      * @return
      */
     public static String switchDateFormat(String dateString) {
-        int length = dateString.length();
-        switch (length) {
-            case 19:
-                if (dateString.contains(MINUS)) {
-                    return DATE_FORMAT_19;
-                } else {
-                    return DATE_FORMAT_19_FORWARD_SLASH;
-                }
-            case 16:
-                if (dateString.contains(MINUS)) {
-                    return DATE_FORMAT_16;
-                } else {
-                    return DATE_FORMAT_16_FORWARD_SLASH;
-                }
-            case 17:
-                return DATE_FORMAT_17;
-            case 14:
-                return DATE_FORMAT_14;
-            case 10:
-                return DATE_FORMAT_10;
-            default:
-                throw new IllegalArgumentException("can not find date format for：" + dateString);
+        String dateS=dateString;
+        if(dateS.contains(MINUS)) {
+            if (dateString.charAt(4) == '-' && dateString.charAt(6) == '-') { //YYYY-M-
+                dateS = dateString.substring(0, 5) + "0" + dateString.substring(5);
+            }
+            if (dateS.length() == 9 || dateS.length() == 10) return DATE_FORMAT_10;  //YYYY-MM-DD
+            if (dateS.charAt(7) == '-' && dateS.charAt(9) == ' ') { //YYYY-MM-D H
+                dateS = dateS.substring(0, 8) + "0" + dateS.substring(8);
+            }
+            if (dateS.charAt(10) == ' ' && dateS.charAt(12) == ':') { //YYYY-MM-DD H:
+                dateS = dateS.substring(0, 11) + "0" + dateS.substring(11);
+            }
+            if (dateS.length() == 15 || dateS.length() == 16) return DATE_FORMAT_16;
+            if (dateS.charAt(13) == ':' && dateS.charAt(15) == ':') { //YYYY-MM-DD HH:M:
+                dateS = dateS.substring(0, 14) + "0" + dateS.substring(14);
+            }
+            if (dateS.length() == 18 || dateS.length() == 19) return DATE_FORMAT_19;
         }
+        else if(dateString.contains("/")){
+            if (dateString.charAt(4) == '/' && dateString.charAt(6) == '/') { //YYYY/M/
+                dateS = dateString.substring(0, 5) + "0" + dateString.substring(5);
+            }
+            if (dateS.length() == 9 || dateS.length() == 10) return DATE_FORMAT_10_FORWARD_SLASH;  //YYYY/MM/DD
+            if (dateS.charAt(7) == '/' && dateS.charAt(9) == ' ') { //YYYY/MM/D H
+                dateS = dateS.substring(0, 8) + "0" + dateS.substring(8);
+            }
+            if (dateS.charAt(10) == ' ' && dateS.charAt(12) == ':') { //YYYY/MM/DD H:
+                dateS = dateS.substring(0, 11) + "0" + dateS.substring(11);
+            }
+            if (dateS.length() == 15 || dateS.length() == 16) return DATE_FORMAT_16_FORWARD_SLASH;
+            if (dateS.charAt(13) == ':' && dateS.charAt(15) == ':') { //YYYY-MM-DD HH:M:
+                dateS = dateS.substring(0, 14) + "0" + dateS.substring(14);
+            }
+            if (dateS.length() == 18 || dateS.length() == 19) return DATE_FORMAT_19_FORWARD_SLASH;
+
+        }else if(dateString.contains(":")){
+            return DATE_FORMAT_17;//有点难规避，比如2020111,难以判断往哪里补位，所以是文档日期的问题
+        }else if(dateString.length()==14) {
+            return DATE_FORMAT_14;
+        }
+        throw new IllegalArgumentException("can not find date format for：" + dateString);
     }
 
     /**

--- a/src/test/java/com/alibaba/easyexcel/test/core/converter/ConverterDataTest.java
+++ b/src/test/java/com/alibaba/easyexcel/test/core/converter/ConverterDataTest.java
@@ -112,7 +112,7 @@ public class ConverterDataTest {
     private List<ConverterWriteData> data() throws Exception {
         List<ConverterWriteData> list = new ArrayList<ConverterWriteData>();
         ConverterWriteData converterWriteData = new ConverterWriteData();
-        converterWriteData.setDate(DateUtils.parseDate("2020-01-01 01:01:01"));
+        converterWriteData.setDate(DateUtils.parseDate("2020-01-1 01:01:01"));
         converterWriteData.setLocalDateTime(DateUtils.parseLocalDateTime("2020-01-01 01:01:01", null, null));
         converterWriteData.setBooleanData(Boolean.TRUE);
         converterWriteData.setBigDecimal(BigDecimal.ONE);
@@ -125,6 +125,24 @@ public class ConverterDataTest {
         converterWriteData.setFloatData((float)1.0);
         converterWriteData.setString("测试");
         converterWriteData.setCellData(new WriteCellData<>("自定义"));
+        list.add(converterWriteData);
+        return list;
+    }
+    private List<ConverterWriteData> datadatetest() throws Exception {
+        List<ConverterWriteData> list = new ArrayList<ConverterWriteData>();
+        ConverterWriteData converterWriteData = new ConverterWriteData();
+        converterWriteData.setDate(DateUtils.parseDate("2020-01-1 01:01:01"));
+        converterWriteData.setDate(DateUtils.parseDate("2020-1-1 01:01:01"));
+        converterWriteData.setDate(DateUtils.parseDate("2022-01-1 9:01:6"));
+        converterWriteData.setDate(DateUtils.parseDate("2020-01-19 2:2:1"));
+        converterWriteData.setDate(DateUtils.parseDate("2021/01/11 01:01:01"));
+        converterWriteData.setDate(DateUtils.parseDate("20201101012221"));
+        converterWriteData.setDate(DateUtils.parseDate("20201121 01:01:01"));
+        converterWriteData.setDate(DateUtils.parseDate("2022/01/21 19:01:16"));
+        converterWriteData.setDate(DateUtils.parseDate("2020/01/19 2:2:1"));
+        converterWriteData.setDate(DateUtils.parseDate("2021/1/1 1:1:1"));
+        converterWriteData.setLocalDateTime(DateUtils.parseLocalDateTime("2020-01-01 01:01:01", null, null));
+
         list.add(converterWriteData);
         return list;
     }


### PR DESCRIPTION
Now it also support like YYYY/M/D this kind of time format that is not that complete. The old virsion use the dataString length to decide which format, but it is not enough. Now Also support YYYY/M/D
并非在原文进行补位，而是在返回format时加强进行判断的逻辑，对原文并未修改，但可以成功parseDate。因为YYYY/MM/DD对于2022/1/1也是可以parse的，只是源代码通过长度返回format的位置逻辑有缺