### PR TITLE
修复了issue#2324 文件不是默认编码格式时出现乱码或者报错的情况

### DIFF
--- a/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/temp/csv/CsvReadTest.java
+++ b/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/temp/csv/CsvReadTest.java
@@ -1,11 +1,6 @@
 package com.alibaba.easyexcel.test.temp.csv;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,7 +36,7 @@ public class CsvReadTest {
     @Test
     public void read1() throws Exception {
         Iterable<CSVRecord> records = CSVFormat.DEFAULT.withNullString("").parse(
-            new FileReader("/Users/zhuangjiaju/IdeaProjects/easyexcel/target/test-classes/t1.csv"));
+            new InputStreamReader(new FileInputStream("/Users/zhuangjiaju/test/test1.csv"),"UTF-8"));
         for (CSVRecord record : records) {
             String lastName = record.get(0);
             String firstName = record.get(1);


### PR DESCRIPTION
FileReader不能指定文件读取格式，只能按默认格式读取，所以在读取不是默认格式的CSV文件时会出现乱码或报错，因此采用new InputStreamReader(new FileInputStream())来读取文件，指定读取文件的格式