### PR TITLE
Upload test

### DIFF
--- a/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/demo/web/UploadDataListener.java
+++ b/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/demo/web/UploadDataListener.java
@@ -51,7 +51,6 @@ public class UploadDataListener implements ReadListener<UploadData> {
 
     /**
      * 所有数据解析完成了 都会来调用
-     *
      * @param context
      */
     @Override

--- a/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/demo/web/WebTest.java
+++ b/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/demo/web/WebTest.java
@@ -17,7 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/demo/web/WebTest.java
+++ b/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/demo/web/WebTest.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -29,7 +30,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class WebTest {
 
     @Autowired
-    private UploadDAO uploadDAO;
+    private UploadDataListener uploadDataListener;
 
     /**
      * 文件下载（失败了会返回一个有部分数据的Excel）
@@ -93,7 +94,7 @@ public class WebTest {
     @PostMapping("upload")
     @ResponseBody
     public String upload(MultipartFile file) throws IOException {
-        EasyExcel.read(file.getInputStream(), UploadData.class, new UploadDataListener(uploadDAO)).sheet().doRead();
+        EasyExcel.read(file.getInputStream(), UploadData.class, uploadDataListener).sheet().doRead();
         return "success";
     }
 


### PR DESCRIPTION
## 文件上传测试案例的一些修改
* `UploadDataListener`使用`SCOPE_PROTOTYPE`代替new创建新对象。
* `UploadDataListener.doAfterAllAnalysed`所有数据解析完成了,判断`cachedDataList`长度大于0才执行写入或其他操作。
*  Override `onException`方法，且在这里清除`cachedDataList`
* 将`cachedDataList`的重置放到`UploadDataListener.saveData`