### PR TITLE
fix getTotalCount deprecate doc

### DIFF
--- a/easyexcel-core/src/main/java/com/alibaba/excel/context/AnalysisContext.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/context/AnalysisContext.java
@@ -123,7 +123,7 @@ public interface AnalysisContext {
      * get total row ,Data may be inaccurate
      *
      * @return
-     * @deprecated please use {@link #readRowHolder()}
+     * @deprecated please use {@link #readSheetHolder()}
      */
     @Deprecated
     Integer getTotalCount();


### PR DESCRIPTION
The new way to get the total number of rows should be to use ReadSheeHolder.getApproximateTotalRowNumber()