### PR TITLE
fix #2702

### DIFF
--- a/easyexcel-core/src/main/java/com/alibaba/excel/write/executor/ExcelWriteFillExecutor.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/write/executor/ExcelWriteFillExecutor.java
@@ -523,7 +523,7 @@ public class ExcelWriteFillExecutor extends AbstractExcelWriteExecutor {
             if (StringUtils.isEmpty(variable)) {
                 continue;
             }
-            int collectPrefixIndex = variable.indexOf(COLLECTION_PREFIX);
+            int collectPrefixIndex = variable.startsWith(COLLECTION_PREFIX);
             if (collectPrefixIndex > -1) {
                 if (collectPrefixIndex != 0) {
                     analysisCell.setPrefix(variable.substring(0, collectPrefixIndex));


### PR DESCRIPTION
集合占位符判断有误所致，集合占位符的点号为第一位，如 `.accountName`，改用 `startsWith` 判断