### PR TITLE
writer的Collection接口改为Iterable接口。 使用更高的抽象, 方便和业务结合使用

### DIFF
--- a/easyexcel-core/src/main/java/com/alibaba/excel/ExcelWriter.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/ExcelWriter.java
@@ -1,7 +1,6 @@
 package com.alibaba.excel;
 
 import java.io.Closeable;
-import java.util.Collection;
 import java.util.function.Supplier;
 
 import com.alibaba.excel.context.WriteContext;
@@ -43,7 +42,7 @@ public class ExcelWriter implements Closeable {
      * @param writeSheet Write to this sheet
      * @return this current writer
      */
-    public ExcelWriter write(Collection<?> data, WriteSheet writeSheet) {
+    public ExcelWriter write(Iterable<?> data, WriteSheet writeSheet) {
         return write(data, writeSheet, null);
     }
 
@@ -54,7 +53,7 @@ public class ExcelWriter implements Closeable {
      * @param writeSheet Write to this sheet
      * @return this current writer
      */
-    public ExcelWriter write(Supplier<Collection<?>> supplier, WriteSheet writeSheet) {
+    public ExcelWriter write(Supplier<Iterable<?>> supplier, WriteSheet writeSheet) {
         return write(supplier.get(), writeSheet, null);
     }
 
@@ -66,7 +65,7 @@ public class ExcelWriter implements Closeable {
      * @param writeTable Write to this table
      * @return this
      */
-    public ExcelWriter write(Collection<?> data, WriteSheet writeSheet, WriteTable writeTable) {
+    public ExcelWriter write(Iterable<?> data, WriteSheet writeSheet, WriteTable writeTable) {
         excelBuilder.addContent(data, writeSheet, writeTable);
         return this;
     }
@@ -79,7 +78,7 @@ public class ExcelWriter implements Closeable {
      * @param writeTable Write to this table
      * @return this
      */
-    public ExcelWriter write(Supplier<Collection<?>> supplier, WriteSheet writeSheet, WriteTable writeTable) {
+    public ExcelWriter write(Supplier<Iterable<?>> supplier, WriteSheet writeSheet, WriteTable writeTable) {
         excelBuilder.addContent(supplier.get(), writeSheet, writeTable);
         return this;
     }

--- a/easyexcel-core/src/main/java/com/alibaba/excel/write/ExcelBuilder.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/write/ExcelBuilder.java
@@ -1,7 +1,5 @@
 package com.alibaba.excel.write;
 
-import java.util.Collection;
-
 import com.alibaba.excel.context.WriteContext;
 import com.alibaba.excel.write.merge.OnceAbsoluteMergeStrategy;
 import com.alibaba.excel.write.metadata.WriteSheet;
@@ -20,10 +18,10 @@ public interface ExcelBuilder {
      *            java basic type or java model extend BaseModel
      * @param writeSheet
      *            Write the sheet
-     * @deprecated please use{@link ExcelBuilder#addContent(Collection, WriteSheet, WriteTable)}
+     * @deprecated please use{@link ExcelBuilder#addContent(Iterable, WriteSheet, WriteTable)}
      */
     @Deprecated
-    void addContent(Collection<?> data, WriteSheet writeSheet);
+    void addContent(Iterable<?> data, WriteSheet writeSheet);
 
     /**
      * WorkBook increase value
@@ -35,7 +33,7 @@ public interface ExcelBuilder {
      * @param writeTable
      *            Write the table
      */
-    void addContent(Collection<?> data, WriteSheet writeSheet, WriteTable writeTable);
+    void addContent(Iterable<?> data, WriteSheet writeSheet, WriteTable writeTable);
 
     /**
      * WorkBook fill value

--- a/easyexcel-core/src/main/java/com/alibaba/excel/write/ExcelBuilderImpl.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/write/ExcelBuilderImpl.java
@@ -1,7 +1,5 @@
 package com.alibaba.excel.write;
 
-import java.util.Collection;
-
 import com.alibaba.excel.context.WriteContext;
 import com.alibaba.excel.context.WriteContextImpl;
 import com.alibaba.excel.enums.WriteTypeEnum;
@@ -44,12 +42,12 @@ public class ExcelBuilderImpl implements ExcelBuilder {
     }
 
     @Override
-    public void addContent(Collection<?> data, WriteSheet writeSheet) {
+    public void addContent(Iterable<?> data, WriteSheet writeSheet) {
         addContent(data, writeSheet, null);
     }
 
     @Override
-    public void addContent(Collection<?> data, WriteSheet writeSheet, WriteTable writeTable) {
+    public void addContent(Iterable<?> data, WriteSheet writeSheet, WriteTable writeTable) {
         try {
             context.currentSheet(writeSheet, WriteTypeEnum.ADD);
             context.currentTable(writeTable);

--- a/easyexcel-core/src/main/java/com/alibaba/excel/write/builder/ExcelWriterSheetBuilder.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/write/builder/ExcelWriterSheetBuilder.java
@@ -55,7 +55,7 @@ public class ExcelWriterSheetBuilder extends AbstractExcelWriterParameterBuilder
         return writeSheet;
     }
 
-    public void doWrite(Collection<?> data) {
+    public void doWrite(Iterable<?> data) {
         if (excelWriter == null) {
             throw new ExcelGenerateException("Must use 'EasyExcelFactory.write().sheet()' to call this method");
         }

--- a/easyexcel-core/src/main/java/com/alibaba/excel/write/executor/ExcelWriteAddExecutor.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/write/executor/ExcelWriteAddExecutor.java
@@ -1,8 +1,8 @@
 package com.alibaba.excel.write.executor;
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -41,9 +41,9 @@ public class ExcelWriteAddExecutor extends AbstractExcelWriteExecutor {
         super(writeContext);
     }
 
-    public void add(Collection<?> data) {
-        if (CollectionUtils.isEmpty(data)) {
-            data = new ArrayList<>();
+    public void add(Iterable<?> data) {
+        if (data == null) {
+            data = Collections.emptyList();
         }
         WriteSheetHolder writeSheetHolder = writeContext.writeSheetHolder();
         int newRowIndex = writeSheetHolder.getNewRowIndexAndStartDoWrite();

--- a/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/demo/write/WriteTest.java
+++ b/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/demo/write/WriteTest.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -40,6 +41,7 @@ import com.alibaba.excel.write.metadata.style.WriteFont;
 import com.alibaba.excel.write.style.HorizontalCellStyleStrategy;
 import com.alibaba.excel.write.style.column.LongestMatchColumnWidthStyleStrategy;
 
+import org.apache.commons.collections4.IteratorUtils;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.FillPatternType;
@@ -57,6 +59,17 @@ import org.junit.Test;
 @Ignore
 public class WriteTest {
 
+
+    @Test
+    public void testPageWrite() {
+        String fileName = TestFileUtil.getPath() + "simpleWrite" + System.currentTimeMillis() + ".xlsx";
+        // data from RPC or Database
+        final Iterator<DemoData> demoDataIterator = IteratorUtils.chainedIterator(
+            data().iterator(),
+            data().iterator());
+        EasyExcel.write(fileName, DemoData.class).sheet("模板")
+            .doWrite(IteratorUtils.asIterable(demoDataIterator));
+    }
     /**
      * 最简单的写
      * <p>


### PR DESCRIPTION
在业务操作时，会通过Iterator抽象获取数据的来源。 例如从RPC,DB获取数据
目前提供的分页示例调用不方便， 如果改成Iterable之后。
可以使用  org.apache.commons.collections4.IteratorUtils#asIterable 将Iterator转为Iterable.
.writer写出数据时，也不需要需要集合的其他元素， 改成Iterable完全没问题

ISSUE:
https://github.com/alibaba/easyexcel/issues/1834


希望能得到回复