### PR TITLE
修复ehcache缓存在目录/tmp被系统清理导致异常 [Issue #2693] 

### DIFF
--- a/easyexcel-core/src/main/java/com/alibaba/excel/cache/Ehcache.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/cache/Ehcache.java
@@ -35,6 +35,8 @@ public class Ehcache implements ReadCache {
     private static final CacheManager FILE_CACHE_MANAGER;
     private static final CacheConfiguration<Integer, ArrayList> FILE_CACHE_CONFIGURATION;
     private static final CacheManager ACTIVE_CACHE_MANAGER;
+    private static final File CACHE_PATH_FILE;
+
     private final CacheConfiguration<Integer, ArrayList> activeCacheConfiguration;
     /**
      * Bulk storage data
@@ -59,9 +61,9 @@ public class Ehcache implements ReadCache {
     }
 
     static {
-        File cacheFile = FileUtils.createCacheTmpFile();
+        CACHE_PATH_FILE = FileUtils.createCacheTmpFile();
         FILE_CACHE_MANAGER =
-            CacheManagerBuilder.newCacheManagerBuilder().with(CacheManagerBuilder.persistence(cacheFile)).build(true);
+            CacheManagerBuilder.newCacheManagerBuilder().with(CacheManagerBuilder.persistence(CACHE_PATH_FILE)).build(true);
         ACTIVE_CACHE_MANAGER = CacheManagerBuilder.newCacheManagerBuilder().build(true);
         FILE_CACHE_CONFIGURATION = CacheConfigurationBuilder
             .newCacheConfigurationBuilder(Integer.class, ArrayList.class,
@@ -72,7 +74,21 @@ public class Ehcache implements ReadCache {
     @Override
     public void init(AnalysisContext analysisContext) {
         cacheAlias = UUID.randomUUID().toString();
-        fileCache = FILE_CACHE_MANAGER.createCache(cacheAlias, FILE_CACHE_CONFIGURATION);
+        try {
+            fileCache = FILE_CACHE_MANAGER.createCache(cacheAlias, FILE_CACHE_CONFIGURATION);
+        } catch (IllegalStateException e) {
+            //fix Issue #2693,重建缓存文件夹
+            if (CACHE_PATH_FILE.exists()) {
+                throw e;
+            }
+            synchronized (Ehcache.class) {
+                if (!CACHE_PATH_FILE.exists()){
+                    log.debug("cache file dir is not exist retry create");
+                    FileUtils.createDirectory(CACHE_PATH_FILE);
+                }
+            }
+            fileCache = FILE_CACHE_MANAGER.createCache(cacheAlias, FILE_CACHE_CONFIGURATION);
+        }
         activeCache = ACTIVE_CACHE_MANAGER.createCache(cacheAlias, activeCacheConfiguration);
     }
 

--- a/easyexcel-core/src/main/java/com/alibaba/excel/util/FileUtils.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/util/FileUtils.java
@@ -174,7 +174,7 @@ public class FileUtils {
      *
      * @param directory
      */
-    private static File createDirectory(File directory) {
+    public static File createDirectory(File directory) {
         if (!directory.exists() && !directory.mkdirs()) {
             throw new ExcelCommonException("Cannot create directory:" + directory.getAbsolutePath());
         }

--- a/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/core/large/LargeDataTest.java
+++ b/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/core/large/LargeDataTest.java
@@ -2,14 +2,19 @@ package com.alibaba.easyexcel.test.core.large;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
 import com.alibaba.easyexcel.test.util.TestFileUtil;
 import com.alibaba.excel.EasyExcel;
 import com.alibaba.excel.ExcelWriter;
+import com.alibaba.excel.cache.Ehcache;
+import com.alibaba.excel.cache.ReadCache;
+import com.alibaba.excel.util.FileUtils;
 import com.alibaba.excel.write.metadata.WriteSheet;
 
+import org.apache.poi.util.TempFile;
 import org.apache.poi.xssf.streaming.SXSSFCell;
 import org.apache.poi.xssf.streaming.SXSSFRow;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
@@ -54,6 +59,7 @@ public class LargeDataTest {
             new LargeDataListener()).headRowNumber(2).sheet().doRead();
         LOGGER.info("Large data total time spent:{}", System.currentTimeMillis() - start);
     }
+
 
     @Test
     public void t02Fill() {
@@ -127,7 +133,18 @@ public class LargeDataTest {
         LOGGER.info("{} vs {}", cost, costPoi);
         Assert.assertTrue(costPoi * 2 > cost);
     }
-
+    @Test
+    public void t05Read() throws Exception {
+        long start = System.currentTimeMillis();
+        EasyExcel.read(TestFileUtil.getPath() + "large" + File.separator + "large07.xlsx", LargeData.class,
+            new LargeDataListener()).headRowNumber(2).sheet().doRead();
+        LOGGER.info("Large data total time spent:{}", System.currentTimeMillis() - start);
+        FileUtils.delete(new File(System.getProperty(TempFile.JAVA_IO_TMPDIR)));
+        start = System.currentTimeMillis();
+        EasyExcel.read(TestFileUtil.getPath() + "large" + File.separator + "large07.xlsx", LargeData.class,
+            new LargeDataListener()).headRowNumber(2).sheet().doRead();
+        LOGGER.info("Large data total time spent:{}", System.currentTimeMillis() - start);
+    }
     private List<LargeData> data() {
         List<LargeData> list = new ArrayList<>();
         int size = i + 100;


### PR DESCRIPTION
复现过程：
1. 在系统运行后
2.  模拟把`/tmp`文件夹删除。
3.  进行数据缓存，则会导致报错
修复：
1.  将初始化方法中创建cacahe进行异常捕获，如缓存文件夹不存在，则创建该缓存文件夹。