### PR TITLE
[add] direct Stream support as read output

### DIFF
--- a/easyexcel-core/src/main/java/com/alibaba/excel/EasyExcelFactory.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/EasyExcelFactory.java
@@ -3,7 +3,10 @@ package com.alibaba.excel;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
+import com.alibaba.excel.context.AnalysisContext;
 import com.alibaba.excel.read.builder.ExcelReaderBuilder;
 import com.alibaba.excel.read.builder.ExcelReaderSheetBuilder;
 import com.alibaba.excel.read.listener.ReadListener;
@@ -244,6 +247,22 @@ public class EasyExcelFactory {
      */
     public static ExcelReaderBuilder read(String pathName, ReadListener readListener) {
         return read(pathName, null, readListener);
+    }
+
+    public static <T> Stream<T> read(String pathName, Class<T> head) {
+        Consumer<Consumer<T>> sequence = c -> {
+            ReadListener<T> listener = new ReadListener<>() {
+                @Override
+                public void invoke(T data, AnalysisContext context) {
+                    c.accept(data);
+                }
+
+                @Override
+                public void doAfterAllAnalysed(AnalysisContext context) {}
+            };
+            read(pathName, head, listener).sheet().doRead();
+        };
+        return StreamBuilder.stream(sequence);
     }
 
     /**

--- a/easyexcel-core/src/main/java/com/alibaba/excel/StreamBuilder.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/StreamBuilder.java
@@ -1,0 +1,36 @@
+package com.alibaba.excel;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * build stream from generator
+ */
+public class StreamBuilder {
+    public static <T> Stream<T> stream(Consumer<Consumer<T>> sequence) {
+        Iterator<T> iterator = new Iterator<>() {
+            @Override
+            public boolean hasNext() {
+                throw new NoSuchElementException();
+            }
+
+            @Override
+            public T next() {
+                throw new NoSuchElementException();
+            }
+
+            @Override
+            public void forEachRemaining(Consumer<? super T> action) {
+                sequence.accept(action::accept);
+            }
+        };
+        return StreamSupport.stream(
+            Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED),
+            false);
+    }
+}


### PR DESCRIPTION
给EasyExcel添加直接的`Stream`支持，不加入任何中间缓存
用户不需要创建匿名`ReadListener`类，甚至不需要感知它的存在
读取Excel的过程直接转化为流式API，也就是`Stream`，之后可以随意聚合为`List`, `Map`或者进行别的任何操作。

这一版提交没有处理`sheet()`等相关可选操作，仅作为原理展示
新增的方法本身是static函数，所以可以随意复制到本地进行测试