### PR TITLE
增加注解@ExcelSubData 来导出有层次结构的数据

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # 🔥作者最新开源项目[Chat2DB](https://github.com/alibaba/Chat2DB)
-[Chat2DB](https://github.com/alibaba/Chat2DB) 智能数据库客户端，数据报表工具，自然语言生成SQL，生成报表。 GitHub地址 [https://github.com/alibaba/Chat2DB](https://github.com/alibaba/Chat2DB)
+[Chat2DB](https://github.com/alibaba/Chat2DB) 智能数据库客户端，比Navicat、DataGrip更智能，体验更好，永久免费无需破解。 GitHub地址 [https://github.com/alibaba/Chat2DB](https://github.com/alibaba/Chat2DB)
 
 EasyExcel
 ======================

--- a/easyexcel-core/src/main/java/com/alibaba/excel/context/WriteContextImpl.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/context/WriteContextImpl.java
@@ -260,9 +260,12 @@ public class WriteContextImpl implements WriteContext {
     }
 
     private void addOneRowOfHeadDataToExcel(Row row, Integer rowIndex, Map<Integer, Head> headMap,
-        int relativeRowIndex) {
+                                            int relativeRowIndex) {
         for (Map.Entry<Integer, Head> entry : headMap.entrySet()) {
             Head head = entry.getValue();
+            if (head.isSubData()) {
+                continue;
+            }
             int columnIndex = entry.getKey();
             ExcelContentProperty excelContentProperty = ClassUtils.declaredExcelContentProperty(null,
                 currentWriteHolder.excelWriteHeadProperty().getHeadClazz(), head.getFieldName(), currentWriteHolder);
@@ -388,7 +391,7 @@ public class WriteContextImpl implements WriteContext {
         try {
             Workbook workbook = writeWorkbookHolder.getWorkbook();
             if (workbook instanceof SXSSFWorkbook) {
-                ((SXSSFWorkbook)workbook).dispose();
+                ((SXSSFWorkbook) workbook).dispose();
             }
         } catch (Throwable t) {
             throwable = t;

--- a/easyexcel-core/src/main/java/com/alibaba/excel/metadata/Head.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/metadata/Head.java
@@ -66,8 +66,41 @@ public class Head {
      */
     private FontProperty headFontProperty;
 
+    /**
+     * is sub data
+     */
+    private boolean isSubData = false;
+    /**
+     * sub data FillForegroundColors
+     */
+    private Short[] subFillForegroundColors;
+
+
+    public Short nextFillForegroundColor(int depth) {
+        if (subFillForegroundColors == null || subFillForegroundColors.length == 0) {
+            return null;
+        }
+        int index = depth;
+
+        if (index == -1) {
+            return null;
+        }
+
+        if (index < subFillForegroundColors.length) {
+            return subFillForegroundColors[index];
+        }
+
+        // 表面上有 len种颜色 实际上 加上没有颜色 应该是有 len+1种
+        index = depth % (subFillForegroundColors.length + 1) - 1;
+        if (index == -1) {
+            return null;
+        }
+        return subFillForegroundColors[index];
+    }
+
+
     public Head(Integer columnIndex, Field field, String fieldName, List<String> headNameList, Boolean forceIndex,
-        Boolean forceName) {
+                Boolean forceName) {
         this.columnIndex = columnIndex;
         this.field = field;
         this.fieldName = fieldName;

--- a/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/demo/write/WriteTest.java
+++ b/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/demo/write/WriteTest.java
@@ -460,7 +460,7 @@ public class WriteTest {
         // 背景设置为红色
         headWriteCellStyle.setFillForegroundColor(IndexedColors.RED.getIndex());
         WriteFont headWriteFont = new WriteFont();
-        headWriteFont.setFontHeightInPoints((short)20);
+        headWriteFont.setFontHeightInPoints((short) 20);
         headWriteCellStyle.setWriteFont(headWriteFont);
         // 内容的策略
         WriteCellStyle contentWriteCellStyle = new WriteCellStyle();
@@ -470,7 +470,7 @@ public class WriteTest {
         contentWriteCellStyle.setFillForegroundColor(IndexedColors.GREEN.getIndex());
         WriteFont contentWriteFont = new WriteFont();
         // 字体大小
-        contentWriteFont.setFontHeightInPoints((short)20);
+        contentWriteFont.setFontHeightInPoints((short) 20);
         contentWriteCellStyle.setWriteFont(contentWriteFont);
         // 这个策略是 头是头的样式 内容是内容的样式 其他的策略可以自己实现
         HorizontalCellStyleStrategy horizontalCellStyleStrategy =
@@ -705,6 +705,16 @@ public class WriteTest {
         EasyExcel.write(fileName).head(head()).sheet("模板").doWrite(dataList());
     }
 
+    /**
+     * 支持嵌套树形结构的用例
+     */
+    @Test
+    public void treeWrite() {
+        String fileName = TestFileUtil.getPath() + "treeWrite" + System.currentTimeMillis() + ".xlsx";
+        // 这里 需要指定写用哪个class去写，然后写到第一个sheet，名字为模板 然后文件流会自动关闭
+        EasyExcel.write(fileName, TreeDemoData.class).sheet("模板").doWrite(treeData());
+    }
+
     private List<LongestMatchColumnWidthData> dataLong() {
         List<LongestMatchColumnWidthData> list = ListUtils.newArrayList();
         for (int i = 0; i < 10; i++) {
@@ -765,6 +775,24 @@ public class WriteTest {
             data.setDate(new Date());
             data.setDoubleData(0.56);
             list.add(data);
+        }
+        return list;
+    }
+
+    private List<TreeDemoData> treeData() {
+        List<TreeDemoData> list = ListUtils.newArrayList();
+        for (int i = 0; i < 10; i++) {
+            TreeDemoData school = new TreeDemoData("学校:" + i, 100.1);
+            list.add(school);
+            for (int j = 0; j < i + 3; j++) {
+                TreeDemoData grade = new TreeDemoData("年级:" + i, 2000.22);
+                school.addSub(grade);
+                for (int k = 0; k < i + 3; k++) {
+                    TreeDemoData mClass = new TreeDemoData("班级:" + i, 333333333.1);
+                    grade.addSub(mClass);
+                }
+
+            }
         }
         return list;
     }


### PR DESCRIPTION
导出excel的时候可以在对象中添加 @ExcelSubData 来导出 tree 结构的数据如：
```java
@Data
public class TreeDemoData {

    @ExcelProperty("字符串标题")
    private String string;
    @ExcelProperty("日期标题")
    private Date date;
    @ExcelProperty("数字标题")
    private Double doubleData;
    // 标注 sub中的数据将使用 group的方式导出，同时不同层级之间使用 “灰色"，”蓝色“ 来区分
    @ExcelSubData(fillForegroundColors = {IndexedColors.GREY_25_PERCENT, IndexedColors.LIGHT_TURQUOISE})
    private List<TreeDemoData> sub = new ArrayList<>();
}
```
如：建立数据结构如下

- 学校1
  -  年级1
     -  班级 1
  -  年级1
     -  班级 1

导出数据如下所示
![image](https://github.com/alibaba/easyexcel/assets/28339044/a306b6d8-9586-497c-98b1-46b31a82e792)

可以参考单元测试 
 com.alibaba.easyexcel.test.demo.write.WriteTest#treeWrite
