### PR TITLE
:hammer: 修复 getRelativeRowIndex 转换int 可能会导致的空指针异常

### DIFF
--- a/easyexcel-core/src/main/java/com/alibaba/excel/write/style/row/AbstractRowHeightStyleStrategy.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/write/style/row/AbstractRowHeightStyleStrategy.java
@@ -29,7 +29,7 @@ public abstract class AbstractRowHeightStyleStrategy implements RowWriteHandler 
      * @param row
      * @param relativeRowIndex
      */
-    protected abstract void setHeadColumnHeight(Row row, int relativeRowIndex);
+    protected abstract void setHeadColumnHeight(Row row, Integer relativeRowIndex);
 
     /**
      * Sets the height of content
@@ -37,6 +37,6 @@ public abstract class AbstractRowHeightStyleStrategy implements RowWriteHandler 
      * @param row
      * @param relativeRowIndex
      */
-    protected abstract void setContentColumnHeight(Row row, int relativeRowIndex);
+    protected abstract void setContentColumnHeight(Row row, Integer relativeRowIndex);
 
 }

--- a/easyexcel-core/src/main/java/com/alibaba/excel/write/style/row/SimpleRowHeightStyleStrategy.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/write/style/row/SimpleRowHeightStyleStrategy.java
@@ -17,14 +17,14 @@ public class SimpleRowHeightStyleStrategy extends AbstractRowHeightStyleStrategy
     }
 
     @Override
-    protected void setHeadColumnHeight(Row row, int relativeRowIndex) {
+    protected void setHeadColumnHeight(Row row, Integer relativeRowIndex) {
         if (headRowHeight != null) {
             row.setHeightInPoints(headRowHeight);
         }
     }
 
     @Override
-    protected void setContentColumnHeight(Row row, int relativeRowIndex) {
+    protected void setContentColumnHeight(Row row, Integer relativeRowIndex) {
         if (contentRowHeight != null) {
             row.setHeightInPoints(contentRowHeight);
         }


### PR DESCRIPTION
在开发中发现此 AbstractRowHeightStyleStrategy 类中，**context.getRelativeRowIndex()** 调用会产生 null 值。而同类的两个抽象方法都是使用int 作为接收参数，转换过程中会存在空指针的异常出现。

同时 默认实现的 `SimpleRowHeightStyleStrategy` 也应该使用 Integer 作为参数接收。

PR修复了以上问题。

```java
    @Override
    public void afterRowDispose(RowWriteHandlerContext context) {
        if (context.getHead() == null) {
            return;
        }
        if (context.getHead()) {
            setHeadColumnHeight(context.getRow(), context.getRelativeRowIndex());
        } else {
            setContentColumnHeight(context.getRow(), context.getRelativeRowIndex());
        }
    }

    protected abstract void setHeadColumnHeight(Row row, int relativeRowIndex);

    protected abstract void setContentColumnHeight(Row row, int relativeRowIndex);
```