### PR TITLE
fix(sec): upgrade ch.qos.logback:logback-classic to 1.4.12

### DIFF
--- a/easyexcel-test/pom.xml
+++ b/easyexcel-test/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.12</version>
+            <version>1.4.12</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in ch.qos.logback:logback-classic 1.2.12
- [CVE-2023-6378](https://www.oscs1024.com/hd/CVE-2023-6378)


### What did I do？
Upgrade ch.qos.logback:logback-classic from 1.2.12 to 1.4.12 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS