### PR TITLE
添加注解`ExcelUnInheritable`,声明不可指定类的`Field`不进行继承

### DIFF
--- a/easyexcel-core/src/main/java/com/alibaba/excel/annotation/ExcelUnInheritable.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/annotation/ExcelUnInheritable.java
@@ -1,0 +1,16 @@
+package com.alibaba.excel.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declare that this type of field is not inheritable
+ *
+ * @author ShuaiJu Sun
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExcelUnInheritable {
+}


### PR DESCRIPTION
### 父类不添加对应注解的情况
父类
```java
@Data
@ExcelIgnoreUnannotated
public class ExportVisitRecordData{
    /**
     * 类目
     */
    @ExcelProperty(value = "类目")
    private String categoryName;
}
```
子类
```java
@Data
@ExcelIgnoreUnannotated
public class ExportVisitRecordDataSub extends ExportVisitRecordData{

    /**
     * 类目
     */
    @ExcelProperty(value = "类目")
    private String categoryName;

}
```
导出结果两列重复的：
![image](https://github.com/alibaba/easyexcel/assets/32637619/00187e4c-b5b2-4b3e-801f-b289f63ef619)


### 父类添加`ExcelUnInheritable`注解

父类
```java
@Data
@ExcelIgnoreUnannotated
@ExcelUnInheritable
public class ExportVisitRecordData{
    /**
     * 类目
     */
    @ExcelProperty(value = "类目")
    private String categoryName;
}
```
导出结果：
![image](https://github.com/alibaba/easyexcel/assets/32637619/6f0677e4-86b8-4d1f-8726-6cde2fcb1194)

