### PR TITLE
新增使用临时文件的选项,避免大量图片导出时OOM

### DIFF
--- a/easyexcel-core/src/main/java/com/alibaba/excel/EasyExcelFactory.java
+++ b/easyexcel-core/src/main/java/com/alibaba/excel/EasyExcelFactory.java
@@ -10,6 +10,7 @@ import com.alibaba.excel.read.listener.ReadListener;
 import com.alibaba.excel.write.builder.ExcelWriterBuilder;
 import com.alibaba.excel.write.builder.ExcelWriterSheetBuilder;
 import com.alibaba.excel.write.builder.ExcelWriterTableBuilder;
+import org.apache.poi.openxml4j.opc.ZipPackage;
 
 /**
  * Reader and writer factory class
@@ -17,6 +18,15 @@ import com.alibaba.excel.write.builder.ExcelWriterTableBuilder;
  * @author jipengfei
  */
 public class EasyExcelFactory {
+
+    /**
+     * @param tempFilePackageParts whether to save package part data in temp files to save memory
+     * default is false
+     * Temporary files prevent OOM, particularly during image export operations.
+     */
+    public static void useTempFilePackageParts(boolean tempFilePackageParts) {
+        ZipPackage.setUseTempFilePackageParts(tempFilePackageParts);
+    }
 
     /**
      * Build excel the write

--- a/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/demo/write/WriteTest.java
+++ b/easyexcel-test/src/test/java/com/alibaba/easyexcel/test/demo/write/WriteTest.java
@@ -94,6 +94,12 @@ public class WriteTest {
             WriteSheet writeSheet = EasyExcel.writerSheet("模板").build();
             excelWriter.write(data(), writeSheet);
         }
+
+        // 写法4
+        fileName = TestFileUtil.getPath() + "simpleWrite" + System.currentTimeMillis() + ".xlsx";
+        // 启用临时文件，影响全局
+        EasyExcel.useTempFilePackageParts(true);
+        EasyExcel.write(fileName, DemoData.class).sheet("模板").doWrite(data());
     }
 
     /**


### PR DESCRIPTION
新增使用临时文件的选项,避免大量图片导出时OOM
默认为false，图片全部放在内存中